### PR TITLE
Fix links in integrations.md v0.3.x. fixes #357 

### DIFF
--- a/book/src/integrations.md
+++ b/book/src/integrations.md
@@ -8,7 +8,7 @@ In your template definitions, replace `rinja::Template` with
 Enabling the `with-rocket` feature appends an implementation of Rocket's
 `Responder` trait for each template type. This makes it easy to trivially
 return a value of that type in a Rocket handler. See
-[the example](https://github.com/rinja-rs/rinja/blob/master/rinja_rocket/tests/basic.rs)
+[the example](https://github.com/rinja-rs/rinja/blob/v0.3.5/rinja_rocket/tests/basic.rs)
 from the Rinja test suite for more on how to integrate.
 
 In case a run-time error occurs during templating, a `500 Internal Server
@@ -23,7 +23,7 @@ In your template definitions, replace `rinja::Template` with
 Enabling the `with-actix-web` feature appends an implementation of Actix-web's
 `Responder` trait for each template type. This makes it easy to trivially return
 a value of that type in an Actix-web handler. See
-[the example](https://github.com/rinja-rs/rinja/blob/master/rinja_actix/tests/basic.rs)
+[the example](https://github.com/rinja-rs/rinja/blob/v0.3.5/rinja_actix/tests/basic.rs)
 from the Rinja test suite for more on how to integrate.
 
 ## Axum integration
@@ -34,7 +34,7 @@ In your template definitions, replace `rinja::Template` with
 Enabling the `with-axum` feature appends an implementation of Axum's
 `IntoResponse` trait for each template type. This makes it easy to trivially
 return a value of that type in a Axum handler. See
-[the example](https://github.com/rinja-rs/rinja/blob/master/rinja_axum/tests/basic.rs)
+[the example](https://github.com/rinja-rs/rinja/blob/v0.3.5/rinja_axum/tests/basic.rs)
 from the Rinja test suite for more on how to integrate.
 
 In case of a run-time error occurring during templating, the response will be of the same
@@ -48,7 +48,7 @@ In your template definitions, replace `rinja::Template` with
 
 Enabling the `with-warp` feature appends an implementation of Warp's `Reply`
 trait for each template type. This makes it simple to return a template from
-a Warp filter. See [the example](https://github.com/rinja-rs/rinja/blob/master/rinja_warp/tests/warp.rs)
+a Warp filter. See [the example](https://github.com/rinja-rs/rinja/blob/v0.3.5/rinja_warp/tests/warp.rs)
 from the Rinja test suite for more on how to integrate.
 
 [rinja_rocket]: https://docs.rs/rinja_rocket


### PR DESCRIPTION
Points to the `v0.3.5` instead of `master`. 

Details in #357 
