### PR TITLE
ci: ignore typos in librustdoc sources

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -10,6 +10,9 @@ extend-exclude = [
     "target/",
     "askama_parser/tests/*.txt",
     "testing/templates/fuzzed-*",
+    # we copied the files verbatim including any typos :)
+    "askama_parser/benches",
+    "askama_derive_standalone/benches",
     # filler texts
     "askama/benches/strings.inc",
     # too many false positives


### PR DESCRIPTION
We copied the sources verbatim, so it's no use to fix any typos.

Also, "typ" is not really a typo in here, because "type" would not have been a valid identifier.