### PR TITLE
ci: re-enable `Cluster-Fuzz`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -218,34 +218,34 @@ jobs:
         env:
           RUSTFLAGS: '-Ctarget-feature=-crt-static'
 
-  # Cluster-Fuzz:
-  #   needs: ["Test", "Package", "MSRV"]
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     security-events: write
-  #   steps:
-  #     - name: Build Fuzzers
-  #       id: build
-  #       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
-  #       with:
-  #         oss-fuzz-project-name: askama
-  #         language: rust
-  #     - name: Run Fuzzers
-  #       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
-  #       with:
-  #         oss-fuzz-project-name: askama
-  #         language: rust
-  #         fuzz-seconds: 600
-  #         output-sarif: true
-  #     - name: Upload Crash
-  #       uses: actions/upload-artifact@v4
-  #       if: failure() && steps.build.outcome == 'success'
-  #       with:
-  #         name: artifacts
-  #         path: ./out/artifacts
-  #     - name: Upload Sarif
-  #       if: always() && steps.build.outcome == 'success'
-  #       uses: github/codeql-action/upload-sarif@v3
-  #       with:
-  #         sarif_file: cifuzz-sarif/results.sarif
-  #         checkout_path: cifuzz-sarif
+  Cluster-Fuzz:
+    needs: ["Test", "Package", "MSRV"]
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Build Fuzzers
+        id: build
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        with:
+          oss-fuzz-project-name: askama
+          language: rust
+      - name: Run Fuzzers
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        with:
+          oss-fuzz-project-name: askama
+          language: rust
+          fuzz-seconds: 600
+          output-sarif: true
+      - name: Upload Crash
+        uses: actions/upload-artifact@v4
+        if: failure() && steps.build.outcome == 'success'
+        with:
+          name: artifacts
+          path: ./out/artifacts
+      - name: Upload Sarif
+        if: always() && steps.build.outcome == 'success'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: cifuzz-sarif/results.sarif
+          checkout_path: cifuzz-sarif


### PR DESCRIPTION
The renaming was just merged upstream: <https://github.com/google/oss-fuzz/pull/13127>. I'm not 100% sure that it's live immediately, but once the tests ran, we'll see.