### PR TITLE
Revive `askama_escaped`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
           set -eu
           for PKG in \
             bench-build examples/actix-web-app examples/axum-app examples/poem-app examples/rocket-app examples/salvo-app examples/warp-app fuzzing \
-            askama askama_derive askama_derive_standalone askama_parser \
+            askama askama_derive askama_derive_standalone askama_escape askama_parser \
             testing testing-alloc testing-no-std testing-renamed
           do
             cd "$PKG"
@@ -117,7 +117,7 @@ jobs:
           set -eu
           for PKG in \
             bench-build examples/actix-web-app examples/axum-app examples/poem-app examples/rocket-app examples/salvo-app examples/warp-app fuzzing \
-            askama askama_derive askama_derive_standalone askama_parser \
+            askama askama_derive askama_derive_standalone askama_escape askama_parser \
             testing testing-alloc testing-no-std testing-renamed
           do
             cd "$PKG"
@@ -160,7 +160,7 @@ jobs:
       matrix:
         package: [
           bench-build, examples/actix-web-app, examples/axum-app, examples/poem-app, examples/rocket-app, examples/salvo-app, examples/warp-app, fuzzing,
-          askama, askama_derive, askama_derive_standalone, askama_parser,
+          askama, askama_derive, askama_derive_standalone, askama_escape, askama_parser,
           testing, testing-alloc, testing-no-std, testing-renamed,
         ]
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "askama",
     "askama_derive",
+    "askama_escape",
     "askama_parser",
     "testing",
     "testing-alloc",

--- a/_typos.toml
+++ b/_typos.toml
@@ -14,7 +14,7 @@ extend-exclude = [
     "askama_parser/benches",
     "askama_derive_standalone/benches",
     # filler texts
-    "askama/benches/strings.inc",
+    "*/benches/strings.inc",
     # too many false positives
     "testing/tests/gen_ws_tests.py",
 ]

--- a/askama_escape/.rustfmt.toml
+++ b/askama_escape/.rustfmt.toml
@@ -1,0 +1,1 @@
+../.rustfmt.toml

--- a/askama_escape/Cargo.toml
+++ b/askama_escape/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "askama_escape"
+version = "0.13.0-pre.0"
+description = "HTML escaping, extracted from Askama"
+keywords = ["html", "escaping"]
+categories = ["no-std", "no-std::no-alloc"]
+homepage = "https://askama.readthedocs.io/"
+repository = "https://github.com/askama-rs/askama"
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+edition = "2021"
+rust-version = "1.81"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
+
+[[bench]]
+name = "all"
+harness = false
+
+[dev-dependencies]
+criterion = "0.5"

--- a/askama_escape/LICENSE-APACHE
+++ b/askama_escape/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/askama_escape/LICENSE-MIT
+++ b/askama_escape/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/askama_escape/README.md
+++ b/askama_escape/README.md
@@ -1,0 +1,31 @@
+# askama_escape: HTML escaping, extracted from [Askama](https://askama.readthedocs.io/)
+
+[![Crates.io](https://img.shields.io/crates/v/askama_escape?logo=rust&style=flat-square&logoColor=white "Crates.io")](https://crates.io/crates/askama)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/askama-rs/askama/rust.yml?branch=master&logo=github&style=flat-square&logoColor=white "GitHub Workflow Status")](https://github.com/askama-rs/askama/actions/workflows/rust.yml)
+[![docs.rs](https://img.shields.io/docsrs/askama_escape?logo=docsdotrs&style=flat-square&logoColor=white "docs.rs")](https://docs.rs/askama_escape/)
+
+Useful if you don't need a template engine, but if you need to escape a text for HTML or XML.
+
+This implementation escapes `'"'`, `'&'`, `'\'',` `'<'` and `'>'`.
+
+### Example
+
+```rust
+use askama_escape::{escape, escape_html, escape_html_char, Html};
+
+assert_eq!(
+    escape("<script>alert('Hello & bye!')</script>", Html).to_string(),
+    "&#60;script&#62;alert(&#39;Hello &#38; bye!&#39;)&#60;/script&#62;",
+);
+
+let mut dest = String::new();
+escape_html(&mut dest, "<script>alert('Hello & bye!')</script>").unwrap();
+assert_eq!(
+    dest,
+    "&#60;script&#62;alert(&#39;Hello &#38; bye!&#39;)&#60;/script&#62;",
+);
+
+let mut dest = String::new();
+escape_html_char(&mut dest, '&').unwrap();
+assert_eq!(dest, "&#38;");
+```

--- a/askama_escape/_typos.toml
+++ b/askama_escape/_typos.toml
@@ -1,0 +1,1 @@
+../_typos.toml

--- a/askama_escape/benches/all.rs
+++ b/askama_escape/benches/all.rs
@@ -1,0 +1,26 @@
+use askama_escape::escape_html;
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+
+criterion_main!(benches);
+criterion_group!(benches, functions);
+
+fn functions(c: &mut Criterion) {
+    c.bench_function("escape_html", escaping);
+    let mut g = c.benchmark_group("all");
+    let bytes = STRINGS.iter().map(|s| s.len() as u64).sum();
+    g.throughput(Throughput::Bytes(bytes));
+    g.bench_function("escape_html", escaping);
+    g.finish();
+}
+
+fn escaping(b: &mut criterion::Bencher<'_>) {
+    let mut dest = String::new();
+    b.iter(|| {
+        for &s in black_box(STRINGS) {
+            dest.clear();
+            black_box(escape_html(&mut dest, s)).unwrap();
+        }
+    });
+}
+
+const STRINGS: &[&str] = include!("strings.inc");

--- a/askama_escape/benches/strings.inc
+++ b/askama_escape/benches/strings.inc
@@ -1,0 +1,1 @@
+../../askama/benches/strings.inc

--- a/askama_escape/clippy.toml
+++ b/askama_escape/clippy.toml
@@ -1,0 +1,1 @@
+../clippy.toml

--- a/askama_escape/deny.toml
+++ b/askama_escape/deny.toml
@@ -1,0 +1,1 @@
+../deny.toml

--- a/askama_escape/src/ascii_str.rs
+++ b/askama_escape/src/ascii_str.rs
@@ -1,0 +1,1 @@
+../../askama/src/ascii_str.rs

--- a/askama_escape/src/html.rs
+++ b/askama_escape/src/html.rs
@@ -1,0 +1,1 @@
+../../askama/src/html.rs

--- a/askama_escape/src/lib.rs
+++ b/askama_escape/src/lib.rs
@@ -1,0 +1,134 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(docsrs), no_std)]
+#![deny(elided_lifetimes_in_paths)]
+#![deny(unreachable_pub)]
+#![deny(missing_docs)]
+#![doc = include_str!("../README.md")]
+
+use core::fmt;
+
+mod ascii_str;
+mod html;
+
+/// Escape for HTML or XML.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Html;
+
+/// Escape for plain text, i.e. pass through unchanged.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Text;
+
+/// An escaper for some context, e.g. [`Html`].
+pub trait Escaper {
+    /// Escaped the input string `string` into `dest`
+    fn write_escaped<W: fmt::Write>(&self, dest: W, string: &str) -> fmt::Result;
+}
+
+impl Escaper for Html {
+    #[inline]
+    fn write_escaped<W: fmt::Write>(&self, dest: W, string: &str) -> fmt::Result {
+        html::write_escaped_str(dest, string)
+    }
+}
+
+impl Escaper for Text {
+    #[inline]
+    fn write_escaped<W: fmt::Write>(&self, mut dest: W, string: &str) -> fmt::Result {
+        dest.write_str(string)
+    }
+}
+
+/// The return type of [`escape()`].
+///
+/// ## Example
+///
+/// ```rust
+/// use askama_escape::{escape, Escaped, Html};
+///
+/// let escaped: Escaped<'_, _> = escape("<script>alert('Hello & bye!')</script>", Html);
+/// assert_eq!(
+///     escaped.to_string(),
+///     "&#60;script&#62;alert(&#39;Hello &#38; bye!&#39;)&#60;/script&#62;",
+/// );
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct Escaped<'a, E: Escaper> {
+    string: &'a str,
+    escaper: E,
+}
+
+impl<E: Escaper> fmt::Display for Escaped<'_, E> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.escaper.write_escaped(f, self.string)
+    }
+}
+
+/// Safely wrap a `string` with some [`escaper`][Escaper] e.g. for the use in [`Html`].
+///
+/// ## Example
+///
+/// ```rust
+/// use askama_escape::{escape, Html};
+///
+/// assert_eq!(
+///     escape("<script>alert('Hello & bye!')</script>", Html).to_string(),
+///     "&#60;script&#62;alert(&#39;Hello &#38; bye!&#39;)&#60;/script&#62;",
+/// );
+/// ```
+#[inline]
+pub fn escape<E: Escaper>(string: &str, escaper: E) -> Escaped<'_, E> {
+    Escaped { string, escaper }
+}
+
+/// HTML/XML escape a string `str` into `dest`.
+///
+/// ## Example
+///
+/// ```rust
+/// use askama_escape::escape_html;
+///
+/// let mut dest = String::new();
+/// escape_html(&mut dest, "<script>alert('Hello & bye!')</script>").unwrap();
+/// assert_eq!(
+///     dest,
+///     "&#60;script&#62;alert(&#39;Hello &#38; bye!&#39;)&#60;/script&#62;",
+/// );
+/// ```
+#[inline]
+pub fn escape_html(dest: impl fmt::Write, src: &str) -> fmt::Result {
+    html::write_escaped_str(dest, src)
+}
+
+/// HTML/XML escape a character `c` into `dest`.
+///
+/// ## Example
+///
+/// ```rust
+/// use askama_escape::escape_html_char;
+///
+/// let mut dest = String::new();
+/// escape_html_char(&mut dest, '&').unwrap();
+/// assert_eq!(dest, "&#38;");
+/// ```
+pub fn escape_html_char(dest: impl fmt::Write, c: char) -> fmt::Result {
+    html::write_escaped_char(dest, c)
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use std::string::ToString;
+
+    use super::*;
+
+    #[test]
+    fn test_escape() {
+        assert_eq!(escape("", Html).to_string(), "");
+        assert_eq!(escape("<&>", Html).to_string(), "&#60;&#38;&#62;");
+        assert_eq!(escape("bla&", Html).to_string(), "bla&#38;");
+        assert_eq!(escape("<foo", Html).to_string(), "&#60;foo");
+        assert_eq!(escape("bla&h", Html).to_string(), "bla&#38;h");
+    }
+}

--- a/askama_escape/tomlfmt.toml
+++ b/askama_escape/tomlfmt.toml
@@ -1,0 +1,1 @@
+../tomlfmt.toml


### PR DESCRIPTION
We adopted `askama_escape` with the other askama crates. It was not updated for quite some time, but still gets 25k+ downloads / day Mon to Fri.

This PR re-adds the crate using our current HTML escaping function.