### PR TITLE
Fix minimum supported `syn` version

### DIFF
--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = { version = "1.0", optional = true }
 memchr = "2"
 quote = { version = "1", default-features = false }
 rustc-hash = "2.0.0"
-syn = { version = "2.0.3", default-features = false, features = ["clone-impls", "derive", "parsing", "printing"] }
+syn = { version = "2.0.41", default-features = false, features = ["clone-impls", "derive", "parsing", "printing"] }
 
 # in `askama_derive_standalone` we opt out of the default features, because we need no native `proc-macro` support
 proc-macro2 = "1"
@@ -36,7 +36,7 @@ proc-macro2 = "1"
 console = "0.15.8"
 prettyplease = "0.2.20"
 similar = "2.6.0"
-syn = { version = "2.0.3", features = ["full"] }
+syn = { version = "2.0.41", features = ["full"] }
 
 # must be the same feature list as for askama
 [features]


### PR DESCRIPTION
Trying to compile askama_derive v0.13.0-pre.0 on a project that still depended on an old `syn` version failed with:

```
error[E0277]: the trait bound `syn::Field: syn::parse_quote::ParseQuote` is not satisfied
   --> /home/paolobarbolini/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/askama_derive-0.13.0-pre.0/src/integration.rs:413:31
    |
413 |             fields.named.push(parse_quote!(#id: #phantom));
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Parse` is not implemented for `syn::Field`
    |
    = help: the following other types implement trait `Parse`:
              Abstract
              AndAnd
              AndEq
              AngleBracketedGenericArguments
              Arm
              At
              BareFnArg
              Become
            and 243 others
    = note: required for `syn::Field` to implement `syn::parse_quote::ParseQuote`
note: required by a bound in `parse_quote`
   --> /home/paolobarbolini/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/syn-2.0.32/src/parse_quote.rs:115:17
    |
115 | pub fn parse<T: ParseQuote>(token_stream: TokenStream) -> T {
    |                 ^^^^^^^^^^ required by this bound in `parse`
    = note: this error originates in the macro `parse_quote` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `syn::Field: syn::parse_quote::ParseQuote` is not satisfied
   --> /home/paolobarbolini/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/askama_derive-0.13.0-pre.0/src/integration.rs:422:33
    |
422 |             fields.unnamed.push(parse_quote!(#phantom));
    |                                 ^^^^^^^^^^^^^^^^^^^^^^ the trait `Parse` is not implemented for `syn::Field`
    |
    = help: the following other types implement trait `Parse`:
              Abstract
              AndAnd
              AndEq
              AngleBracketedGenericArguments
              Arm
              At
              BareFnArg
              Become
            and 243 others
    = note: required for `syn::Field` to implement `syn::parse_quote::ParseQuote`
note: required by a bound in `parse_quote`
   --> /home/paolobarbolini/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/syn-2.0.32/src/parse_quote.rs:115:17
    |
115 | pub fn parse<T: ParseQuote>(token_stream: TokenStream) -> T {
    |                 ^^^^^^^^^^ required by this bound in `parse`
    = note: this error originates in the macro `parse_quote` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This happens because askama_derive uses an API introduced in [`syn` v2.0.41](https://github.com/dtolnay/syn/releases/tag/2.0.41), but even if were to test it's own project against `-Zminimal-versions` it would be saved by the higher minimum required version by `serde_derive` and `prettyplease`, while it wouldn't when used as a crates.io dependency of another project.