### PR TITLE
Bump version number to 0.13.0

### DIFF
--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama"
-version = "0.13.0-pre.0"
+version = "0.13.0"
 description = "Type-safe, compiled Jinja-like templates for Rust"
 keywords = ["markup", "template", "jinja2", "html"]
 categories = ["template-engine"]
@@ -27,7 +27,7 @@ harness = false
 itoa = "1.0.11"
 
 # needed by feature "derive"
-askama_derive = { version = "=0.13.0-pre.0", path = "../askama_derive", default-features = false, optional = true }
+askama_derive = { version = "=0.13.0", path = "../askama_derive", default-features = false, optional = true }
 
 # needed by feature "serde_json"
 serde = { version = "1.0", optional = true, default-features = false }

--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama_derive"
-version = "0.13.0-pre.0"
+version = "0.13.0"
 description = "Procedural macro package for Askama"
 homepage = "https://github.com/askama-rs/askama"
 repository = "https://github.com/askama-rs/askama"
@@ -17,7 +17,7 @@ rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 proc-macro = true
 
 [dependencies]
-parser = { package = "askama_parser", version = "=0.13.0-pre.0", path = "../askama_parser" }
+parser = { package = "askama_parser", version = "=0.13.0", path = "../askama_parser" }
 
 basic-toml = { version = "0.1.1", optional = true }
 pulldown-cmark = { version = "0.13.0", optional = true, default-features = false }

--- a/askama_derive_standalone/Cargo.toml
+++ b/askama_derive_standalone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama_derive_standalone"
-version = "0.13.0-pre.0"
+version = "0.13.0"
 description = "Procedural macro package for Askama"
 homepage = "https://github.com/askama-rs/askama"
 repository = "https://github.com/askama-rs/askama"
@@ -20,7 +20,7 @@ harness = false
 required-features = ["__standalone"]
 
 [dependencies]
-parser = { package = "askama_parser", version = "=0.13.0-pre.0", path = "../askama_parser" }
+parser = { package = "askama_parser", version = "=0.13.0", path = "../askama_parser" }
 
 basic-toml = { version = "0.1.1", optional = true }
 pulldown-cmark = { version = "0.12.0", optional = true, default-features = false }

--- a/askama_escape/Cargo.toml
+++ b/askama_escape/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama_escape"
-version = "0.13.0-pre.0"
+version = "0.13.0"
 description = "HTML escaping, extracted from Askama"
 keywords = ["html", "escaping"]
 categories = ["no-std", "no-std::no-alloc"]

--- a/askama_parser/Cargo.toml
+++ b/askama_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama_parser"
-version = "0.13.0-pre.0"
+version = "0.13.0"
 description = "Parser for Askama templates"
 documentation = "https://docs.rs/askama"
 keywords = ["markup", "template", "jinja2", "html"]

--- a/bench-build/Cargo.toml
+++ b/bench-build/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "bench-build"
-version = "0.13.0-pre.0"
+version = "0.13.0"
 authors = ["askama-rs developers"]
 edition = "2021"
 rust-version = "1.81"
 publish = false
 
 [dependencies]
-askama = { path = "../askama", version = "0.13.0-pre.0", default-features = false, features = ["std"] }
-askama_derive = { path = "../askama_derive", version = "0.13.0-pre.0", features = ["std"] }
+askama = { path = "../askama", version = "0.13.0", default-features = false, features = ["std"] }
+askama_derive = { path = "../askama_derive", version = "0.13.0", features = ["std"] }
 
 [features]
 default = []

--- a/bench-build/README.md
+++ b/bench-build/README.md
@@ -41,8 +41,8 @@ Without the feature, `cargo` will be able to compile more dependencies in parall
 ```toml
 # Cargo.toml
 [dependencies]
-askama = { version = "0.13.0-pre.0", default-features = false, features = ["std"] }
-askama_derive = { version = "0.13.0-pre.0", features = ["std"] }
+askama = { version = "0.13.0", default-features = false, features = ["std"] }
+askama_derive = { version = "0.13.0", features = ["std"] }
 ```
 
 ```rust

--- a/examples/actix-web-app/Cargo.toml
+++ b/examples/actix-web-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-app"
-version = "0.13.0-pre.0"
+version = "0.13.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -9,7 +9,7 @@ publish = false
 # and actix-web as your web-framework.
 [dependencies]
 actix-web = { version = "4.9.0", default-features = false, features = ["macros"] }
-askama = { version = "0.13.0-pre.0", path = "../../askama" }
+askama = { version = "0.13.0", path = "../../askama" }
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 
 # serde and strum are used to parse (deserialize) and generate (serialize) information

--- a/examples/axum-app/Cargo.toml
+++ b/examples/axum-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-app"
-version = "0.13.0-pre.0"
+version = "0.13.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -8,7 +8,7 @@ publish = false
 # This is an example application that uses both askama as template engine,
 # and axum as your web-framework.
 [dependencies]
-askama = { version = "0.13.0-pre.0", path = "../../askama" }
+askama = { version = "0.13.0", path = "../../askama" }
 axum = "0.8.1"
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 

--- a/examples/poem-app/Cargo.toml
+++ b/examples/poem-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poem-app"
-version = "0.13.0-pre.0"
+version = "0.13.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -8,7 +8,7 @@ publish = false
 # This is an example application that uses both askama as template engine,
 # and poem as your web-framework.
 [dependencies]
-askama = { version = "0.13.0-pre.0", path = "../../askama" }
+askama = { version = "0.13.0", path = "../../askama" }
 poem = "3.1.6"
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 

--- a/examples/rocket-app/Cargo.toml
+++ b/examples/rocket-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-app"
-version = "0.13.0-pre.0"
+version = "0.13.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -8,7 +8,7 @@ publish = false
 # This is an example application that uses both askama as template engine,
 # and rocket as your web-framework.
 [dependencies]
-askama = { version = "0.13.0-pre.0", path = "../../askama" }
+askama = { version = "0.13.0", path = "../../askama" }
 rocket = "0.5.1"
 
 # strum is used to parse and serialize information between web requests,

--- a/examples/salvo-app/Cargo.toml
+++ b/examples/salvo-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salvo-app"
-version = "0.13.0-pre.0"
+version = "0.13.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -8,7 +8,7 @@ publish = false
 # This is an example application that uses both askama as template engine,
 # and salvo as your web-framework.
 [dependencies]
-askama = { version = "0.13.0-pre.0", path = "../../askama" }
+askama = { version = "0.13.0", path = "../../askama" }
 salvo = { version = "0.76.0", default-features = false, features = ["http1", "logging", "server"] }
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 

--- a/examples/warp-app/Cargo.toml
+++ b/examples/warp-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-app"
-version = "0.13.0-pre.0"
+version = "0.13.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -8,7 +8,7 @@ publish = false
 # This is an example application that uses both askama as template engine,
 # and actix-web as your web-framework.
 [dependencies]
-askama = { version = "0.13.0-pre.0", path = "../../askama" }
+askama = { version = "0.13.0", path = "../../askama" }
 http = "0.2.12"
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 warp = "0.3.7"

--- a/testing-alloc/Cargo.toml
+++ b/testing-alloc/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "askama_testing-alloc"
-version = "0.13.0-pre.0"
+version = "0.13.0"
 authors = ["askama-rs developers"]
 edition = "2021"
 rust-version = "1.81"
 publish = false
 
 [dev-dependencies]
-askama = { path = "../askama", version = "0.13.0-pre.0", default-features = false, features = ["alloc", "derive"] }
+askama = { path = "../askama", version = "0.13.0", default-features = false, features = ["alloc", "derive"] }
 
 assert_matches = "1.5.0"

--- a/testing-no-std/Cargo.toml
+++ b/testing-no-std/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "askama_testing-no-std"
-version = "0.13.0-pre.0"
+version = "0.13.0"
 authors = ["askama-rs developers"]
 edition = "2021"
 rust-version = "1.81"
 publish = false
 
 [dev-dependencies]
-askama = { path = "../askama", version = "0.13.0-pre.0", default-features = false, features = ["derive"] }
+askama = { path = "../askama", version = "0.13.0", default-features = false, features = ["derive"] }
 
 assert_matches = "1.5.0"

--- a/testing-renamed/Cargo.toml
+++ b/testing-renamed/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "askama_testing-renamed"
-version = "0.13.0-pre.0"
+version = "0.13.0"
 authors = ["askama-rs developers"]
 edition = "2021"
 rust-version = "1.81"
 publish = false
 
 [dev-dependencies]
-some_name = { package = "askama", path = "../askama", version = "0.13.0-pre.0", default-features = false, features = ["derive"] }
+some_name = { package = "askama", path = "../askama", version = "0.13.0", default-features = false, features = ["derive"] }
 
 assert_matches = "1.5.0"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama_testing"
-version = "0.13.0-pre.0"
+version = "0.13.0"
 authors = ["askama-rs developers"]
 edition = "2021"
 rust-version = "1.81"
@@ -15,7 +15,7 @@ name = "normalize_identifier"
 harness = false
 
 [dependencies]
-askama = { path = "../askama", version = "0.13.0-pre.0" }
+askama = { path = "../askama", version = "0.13.0" }
 
 serde_json = { version = "1.0", optional = true }
 
@@ -23,7 +23,7 @@ serde_json = { version = "1.0", optional = true }
 core = { package = "intentionally-empty", version = "1.0.0" }
 
 [dev-dependencies]
-askama = { path = "../askama", version = "0.13.0-pre.0", features = ["blocks", "code-in-doc", "serde_json"] }
+askama = { path = "../askama", version = "0.13.0", features = ["blocks", "code-in-doc", "serde_json"] }
 
 assert_matches = "1.5.0"
 criterion = "0.5"


### PR DESCRIPTION
I think we are ready for the stable release. We got a few testimonials (thank you!) and I tested upgrading a few code bases myself. Everything seems to work.

After releasing the stable version, I'd wait a few days, then we can add a deprecation notice to rinja.