### PR TITLE
`askama_derive` accidentally exposed as a feature

### DIFF
--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -56,7 +56,7 @@ alloc = [
 blocks = ["askama_derive?/blocks"]
 code-in-doc = ["askama_derive?/code-in-doc"]
 config = ["askama_derive?/config"]
-derive = ["askama_derive"]
+derive = ["dep:askama_derive"]
 serde_json = ["std", "askama_derive?/serde_json", "dep:serde", "dep:serde_json"]
 std = [
     "alloc",


### PR DESCRIPTION
If you don't use an optional dependency at least once with `dep:…` in a feature, it automatically, implicitly becomes a feature flag. The `dep:` prefix was missing from `askama_derive` for the `derive` feature.