### PR TITLE
Deterministic CodeGen

### DIFF
--- a/askama_derive/src/input.rs
+++ b/askama_derive/src/input.rs
@@ -9,7 +9,6 @@ use std::sync::{Arc, OnceLock};
 use parser::node::Whitespace;
 use parser::{Node, Parsed};
 use proc_macro2::Span;
-use rustc_hash::FxBuildHasher;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{Attribute, Expr, ExprLit, ExprPath, Ident, Lit, LitBool, LitStr, Meta, Token};
@@ -150,7 +149,7 @@ impl TemplateInput<'_> {
 
     pub(crate) fn find_used_templates(
         &self,
-        map: &mut HashMap<Arc<Path>, Arc<Parsed>, FxBuildHasher>,
+        map: &mut HashMap<Arc<Path>, Arc<Parsed>, crate::BuildHasherType>,
     ) -> Result<(), CompileError> {
         let (source, source_path) = match &self.source {
             Source::Source(s) => (s.clone(), None),


### PR DESCRIPTION
# Support  for non-cargo build systems

The use of a `HasherBuilder` that uses a random seed results in indeterminism in the code genera by `askama_derive`. This is fine for Cargo projects, however it causes issues with build systems (Buck2 in our case) that use a crate hashes.

# Solution

I've defined:

```rust
// askama_derive/lib.rs
type BuildHasherType = rustc_hash::FxSeededState;
const BUILD_HASHER = rustc_hash::FxSeededState::with_seed(1234); 
```

And updated all uses of `HashMap` in the crate to use the type alias & `BUILD_HASHER`, makes it easy to conditionally swap back to the random seed `HashBuilder` if you wanted to:

1. Gate the fixed seed hasher behind a feature or vice versa (although it shouldn't make a difference so I wouldn't bother),
2. Use a different hasher entirely if you feel like it...


# Draft

We're currently validating that this patch solves our problem, similar solutions have worked for us in the past for other dependencies, so should do.