### PR TITLE
If using local variable as value when creating a new variable, do not put it behind a reference

### DIFF
--- a/askama_derive/src/generator/node.rs
+++ b/askama_derive/src/generator/node.rs
@@ -965,7 +965,11 @@ impl<'a> Generator<'a, '_> {
         }
 
         self.visit_target(buf, true, true, &l.var);
-        let (before, after) = if !is_copyable(val) {
+        // If it's not taking the ownership of a local variable or copyable, then we need to add
+        // a reference.
+        let (before, after) = if !matches!(**val, Expr::Var(name) if self.locals.get(name).is_some())
+            && !is_copyable(val)
+        {
             ("&(", ")")
         } else {
             ("", "")

--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -65,6 +65,16 @@ Like Rust, Askama also supports shadowing variables.
 
 For compatibility with Jinja, `set` can be used in place of `let`.
 
+### Borrow rules
+
+In some cases, the value of a variable initialization will be put behind a reference
+to prevent changing ownership. The rules are as follows:
+
+ * If the value is an expression of more than one element (like `x + 2`), it WILL NOT BE put behind a reference.
+ * If the value is a variable defined in the templates, it WILL NOT BE put behind a reference.
+ * If the value has a filter applied to it (`x|capitalize`), it WILL NOT BE put behind a reference.
+ * If the value is a field (`x.y`), it WILL BE put behind a reference.
+
 ## Filters
 
 Values such as those obtained from variables can be post-processed

--- a/testing/tests/vars.rs
+++ b/testing/tests/vars.rs
@@ -151,3 +151,48 @@ fn test_not_moving_fields_in_var() {
     };
     assert_eq!(x.render().unwrap(), "a/a");
 }
+
+// Ensure that using a local variable as value when creating
+// another variable will not be behind a reference.
+#[test]
+fn test_moving_local_vars() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
+{%- let a = 1 -%}
+{%- if a == 1 %}A{% endif -%}
+{%- let b = a -%}
+{%- if b == 1 %}B{% endif -%}
+{%- let c = a + 0 -%}
+{%- if c == 1 %}C{% endif -%}
+{% let d = x %}
+{%- if *d == 1 %}D{% endif -%}
+{%- let e = y -%}
+{%- if e == "a" %}E{% endif -%}
+{%- let f = Bla::new() -%}
+{%- if f.x == 0 %}F{% endif -%}
+{%- let g = f.x -%}
+{%- if *g == 0 %}G{% endif -%}
+    "#,
+        ext = "txt"
+    )]
+    struct X {
+        x: u32,
+        y: String,
+    }
+    struct Bla {
+        x: u32,
+    }
+
+    impl Bla {
+        fn new() -> Self {
+            Self { x: 0 }
+        }
+    }
+
+    let x = X {
+        x: 1,
+        y: "a".to_owned(),
+    };
+    assert_eq!(x.render().unwrap(), "ABCDEFG");
+}


### PR DESCRIPTION
Fixes #386.

Nothing tricky here, just an extra check. However, it adds more tests to enforce it and added explanations about it in the book. :)