### PR TITLE
Do not put question mark initialization expressions behind a reference

### DIFF
--- a/askama_derive/src/generator/node.rs
+++ b/askama_derive/src/generator/node.rs
@@ -967,7 +967,8 @@ impl<'a> Generator<'a, '_> {
         self.visit_target(buf, true, true, &l.var);
         // If it's not taking the ownership of a local variable or copyable, then we need to add
         // a reference.
-        let (before, after) = if !matches!(**val, Expr::Var(name) if self.locals.get(name).is_some())
+        let (before, after) = if !matches!(**val, Expr::Try(..))
+            && !matches!(**val, Expr::Var(name) if self.locals.get(name).is_some())
             && !is_copyable(val)
         {
             ("&(", ")")

--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -74,6 +74,7 @@ to prevent changing ownership. The rules are as follows:
  * If the value is a variable defined in the templates, it WILL NOT BE put behind a reference.
  * If the value has a filter applied to it (`x|capitalize`), it WILL NOT BE put behind a reference.
  * If the value is a field (`x.y`), it WILL BE put behind a reference.
+ * If the expression ends with a question mark (like `x?`), it WILL NOT BE put behind a reference.
 
 ## Filters
 

--- a/testing/tests/vars.rs
+++ b/testing/tests/vars.rs
@@ -196,3 +196,29 @@ fn test_moving_local_vars() {
     };
     assert_eq!(x.render().unwrap(), "ABCDEFG");
 }
+
+// Ensure that if a variable initialization expression ends with a `?`, we don't put it behind
+// a reference.
+#[test]
+fn test_variable_from_question_mark_init_expr() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
+{%- let v2 = v.as_str().ok_or("error")? %}
+{%- if v2 == "foo" %}1{% endif -%}
+"#,
+        ext = "txt"
+    )]
+    struct X {
+        v: B,
+    }
+
+    struct B;
+    impl B {
+        fn as_str(&self) -> Option<&'static str> {
+            Some("foo")
+        }
+    }
+
+    assert_eq!(X { v: B }.render().unwrap(), "1");
+}


### PR DESCRIPTION
Fixes #399.

I couldn't find any case where it would be an issue to add a reference so I suppose it's all good. :D