### PR TITLE
 Implement `first` and `blank` arguments for `|indent`

### DIFF
--- a/askama/src/filters/mod.rs
+++ b/askama/src/filters/mod.rs
@@ -22,8 +22,8 @@ mod urlencode;
 
 #[cfg(feature = "alloc")]
 pub use self::alloc::{
-    capitalize, fmt, format, indent, linebreaks, linebreaksbr, lower, lowercase, paragraphbreaks,
-    title, trim, upper, uppercase, wordcount,
+    AsIndent, capitalize, fmt, format, indent, linebreaks, linebreaksbr, lower, lowercase,
+    paragraphbreaks, title, trim, upper, uppercase, wordcount,
 };
 pub use self::builtin::{PluralizeCount, center, join, pluralize, truncate};
 pub use self::escape::{
@@ -32,7 +32,7 @@ pub use self::escape::{
 };
 pub use self::humansize::filesizeformat;
 #[cfg(feature = "serde_json")]
-pub use self::json::{AsIndent, json, json_pretty};
+pub use self::json::{json, json_pretty};
 #[cfg(feature = "urlencode")]
 pub use self::urlencode::{urlencode, urlencode_strict};
 

--- a/askama_derive/src/lib.rs
+++ b/askama_derive/src/lib.rs
@@ -603,7 +603,6 @@ pub(crate) use {fmt_left, fmt_right};
 const BUILTIN_FILTERS: &[&str] = &[
     "capitalize",
     "center",
-    "indent",
     "lower",
     "lowercase",
     "title",

--- a/book/src/filters.md
+++ b/book/src/filters.md
@@ -173,6 +173,24 @@ hello
     bar
 ```
 
+The first argument can also be a string that will be used to indent lines.
+
+The first line and blank lines are not indented by default.
+The filter has two optional [`bool`] arguments `first` and `blank`, that can be set to `true`
+to indent the first and blank lines, resp.:
+
+```jinja
+{{ "hello\n\nbar" | indent("$ ", true, true) }}
+```
+
+Output:
+
+```text
+$ hello
+$ 
+$ bar
+```
+
 ### join
 [#join]: #join
 

--- a/testing/tests/filter_block.rs
+++ b/testing/tests/filter_block.rs
@@ -154,7 +154,7 @@ HELLO
 fn filter_block_chaining_paren_followed_by_whitespace() {
     #[derive(Template)]
     #[template(
-        source = r#"{% filter lower|indent(2) -%}
+        source = r#"{% filter lower|indent("> ") -%}
 HELLO
 {{v}}
 {%- endfilter %}
@@ -183,7 +183,7 @@ HELLO
     assert_eq!(
         template.render().unwrap(),
         r"hello
-  pika
+> pika
 
 hello
   pika


### PR DESCRIPTION
For feature parity with Jinja: <https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.indent>

Resolves <https://github.com/askama-rs/askama/issues/193>.