### PR TITLE
Deprecation messages for askama integration crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,11 @@
 [workspace]
-members = ["rinja", "rinja_derive", "rinja_parser"]
+members = [
+    "askama_actix",
+    "askama_axum",
+    "askama_rocket",
+    "askama_warp",
+    "rinja",
+    "rinja_derive",
+    "rinja_parser",
+]
 resolver = "2"

--- a/askama_actix/.rustfmt.toml
+++ b/askama_actix/.rustfmt.toml
@@ -1,0 +1,1 @@
+../.rustfmt.toml

--- a/askama_actix/Cargo.toml
+++ b/askama_actix/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "askama_actix"
+version = "0.15.0+deprecated"
+description = "Integration crates like `askama_actix` were removed from askama 0.13."
+homepage = "https://crates.io/crates/askama"
+repository = "https://github.com/rinja-rs/rinja"
+license = "MIT OR Apache-2.0"
+edition = "2021"
+rust-version = "1.81"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]

--- a/askama_actix/LICENSE-APACHE
+++ b/askama_actix/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/askama_actix/LICENSE-MIT
+++ b/askama_actix/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/askama_actix/README.md
+++ b/askama_actix/README.md
@@ -1,0 +1,8 @@
+# askama_actix — *deprecated*
+
+Integration crates like `askama_actix` were removed from askama 0.13.
+
+Useful information can be found in our [upgrade guide], and in our [blog post].
+
+[upgrade guide]: https://askama.readthedocs.io/en/v0.13.0/upgrading.html
+[blog post]: https://blog.guillaume-gomez.fr/articles/2025-03-19+Askama+and+Rinja+merge

--- a/askama_actix/_typos.toml
+++ b/askama_actix/_typos.toml
@@ -1,0 +1,1 @@
+../_typos.toml

--- a/askama_actix/clippy.toml
+++ b/askama_actix/clippy.toml
@@ -1,0 +1,1 @@
+../clippy.toml

--- a/askama_actix/deny.toml
+++ b/askama_actix/deny.toml
@@ -1,0 +1,1 @@
+../deny.toml

--- a/askama_actix/src/lib.rs
+++ b/askama_actix/src/lib.rs
@@ -1,0 +1,13 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![no_std]
+#![doc = include_str!("../README.md")]
+
+#[cfg(not(docsrs))]
+compile_error!(
+    "\
+    Integration crates like `askama_actix` were removed from askama 0.13.\n\
+    Useful information can be found in our upgrade guide \
+    <https://askama.readthedocs.io/en/v0.13.0/upgrading.html>, \
+    and in our blog post <https://blog.guillaume-gomez.fr/articles/2025-03-19+Askama+and+Rinja+merge>.\
+    "
+);

--- a/askama_actix/tomlfmt.toml
+++ b/askama_actix/tomlfmt.toml
@@ -1,0 +1,1 @@
+../tomlfmt.toml

--- a/askama_axum/.rustfmt.toml
+++ b/askama_axum/.rustfmt.toml
@@ -1,0 +1,1 @@
+../.rustfmt.toml

--- a/askama_axum/Cargo.toml
+++ b/askama_axum/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "askama_axum"
+version = "0.5.0+deprecated"
+description = "Integration crates like `askama_axum` were removed from askama 0.13."
+homepage = "https://crates.io/crates/askama"
+repository = "https://github.com/rinja-rs/rinja"
+license = "MIT OR Apache-2.0"
+edition = "2021"
+rust-version = "1.81"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]

--- a/askama_axum/LICENSE-APACHE
+++ b/askama_axum/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/askama_axum/LICENSE-MIT
+++ b/askama_axum/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/askama_axum/README.md
+++ b/askama_axum/README.md
@@ -1,0 +1,8 @@
+# askama_axum — *deprecated*
+
+Integration crates like `askama_axum` were removed from askama 0.13.
+
+Useful information can be found in our [upgrade guide], and in our [blog post].
+
+[upgrade guide]: https://askama.readthedocs.io/en/v0.13.0/upgrading.html
+[blog post]: https://blog.guillaume-gomez.fr/articles/2025-03-19+Askama+and+Rinja+merge

--- a/askama_axum/_typos.toml
+++ b/askama_axum/_typos.toml
@@ -1,0 +1,1 @@
+../_typos.toml

--- a/askama_axum/clippy.toml
+++ b/askama_axum/clippy.toml
@@ -1,0 +1,1 @@
+../clippy.toml

--- a/askama_axum/deny.toml
+++ b/askama_axum/deny.toml
@@ -1,0 +1,1 @@
+../deny.toml

--- a/askama_axum/src/lib.rs
+++ b/askama_axum/src/lib.rs
@@ -1,0 +1,13 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![no_std]
+#![doc = include_str!("../README.md")]
+
+#[cfg(not(docsrs))]
+compile_error!(
+    "\
+    Integration crates like `askama_axum` were removed from askama 0.13.\n\
+    Useful information can be found in our upgrade guide \
+    <https://askama.readthedocs.io/en/v0.13.0/upgrading.html>, \
+    and in our blog post <https://blog.guillaume-gomez.fr/articles/2025-03-19+Askama+and+Rinja+merge>.\
+    "
+);

--- a/askama_axum/tomlfmt.toml
+++ b/askama_axum/tomlfmt.toml
@@ -1,0 +1,1 @@
+../tomlfmt.toml

--- a/askama_rocket/.rustfmt.toml
+++ b/askama_rocket/.rustfmt.toml
@@ -1,0 +1,1 @@
+../.rustfmt.toml

--- a/askama_rocket/Cargo.toml
+++ b/askama_rocket/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "askama_rocket"
+version = "0.13.0+deprecated"
+description = "Integration crates like `askama_rocket` were removed from askama 0.13."
+homepage = "https://crates.io/crates/askama"
+repository = "https://github.com/rinja-rs/rinja"
+license = "MIT OR Apache-2.0"
+edition = "2021"
+rust-version = "1.81"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]

--- a/askama_rocket/LICENSE-APACHE
+++ b/askama_rocket/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/askama_rocket/LICENSE-MIT
+++ b/askama_rocket/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/askama_rocket/README.md
+++ b/askama_rocket/README.md
@@ -1,0 +1,8 @@
+# askama_rocket — *deprecated*
+
+Integration crates like `askama_rocket` were removed from askama 0.13.
+
+Useful information can be found in our [upgrade guide], and in our [blog post].
+
+[upgrade guide]: https://askama.readthedocs.io/en/v0.13.0/upgrading.html
+[blog post]: https://blog.guillaume-gomez.fr/articles/2025-03-19+Askama+and+Rinja+merge

--- a/askama_rocket/_typos.toml
+++ b/askama_rocket/_typos.toml
@@ -1,0 +1,1 @@
+../_typos.toml

--- a/askama_rocket/clippy.toml
+++ b/askama_rocket/clippy.toml
@@ -1,0 +1,1 @@
+../clippy.toml

--- a/askama_rocket/deny.toml
+++ b/askama_rocket/deny.toml
@@ -1,0 +1,1 @@
+../deny.toml

--- a/askama_rocket/src/lib.rs
+++ b/askama_rocket/src/lib.rs
@@ -1,0 +1,13 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![no_std]
+#![doc = include_str!("../README.md")]
+
+#[cfg(not(docsrs))]
+compile_error!(
+    "\
+    Integration crates like `askama_rocket` were removed from askama 0.13.\n\
+    Useful information can be found in our upgrade guide \
+    <https://askama.readthedocs.io/en/v0.13.0/upgrading.html>, \
+    and in our blog post <https://blog.guillaume-gomez.fr/articles/2025-03-19+Askama+and+Rinja+merge>.\
+    "
+);

--- a/askama_rocket/tomlfmt.toml
+++ b/askama_rocket/tomlfmt.toml
@@ -1,0 +1,1 @@
+../tomlfmt.toml

--- a/askama_warp/.rustfmt.toml
+++ b/askama_warp/.rustfmt.toml
@@ -1,0 +1,1 @@
+../.rustfmt.toml

--- a/askama_warp/Cargo.toml
+++ b/askama_warp/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "askama_warp"
+version = "0.14.0+deprecated"
+description = "Integration crates like `askama_warp` were removed from askama 0.13."
+homepage = "https://crates.io/crates/askama"
+repository = "https://github.com/rinja-rs/rinja"
+license = "MIT OR Apache-2.0"
+edition = "2021"
+rust-version = "1.81"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]

--- a/askama_warp/LICENSE-APACHE
+++ b/askama_warp/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/askama_warp/LICENSE-MIT
+++ b/askama_warp/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/askama_warp/README.md
+++ b/askama_warp/README.md
@@ -1,0 +1,8 @@
+# askama_warp — *deprecated*
+
+Integration crates like `askama_warp` were removed from askama 0.13.
+
+Useful information can be found in our [upgrade guide], and in our [blog post].
+
+[upgrade guide]: https://askama.readthedocs.io/en/v0.13.0/upgrading.html
+[blog post]: https://blog.guillaume-gomez.fr/articles/2025-03-19+Askama+and+Rinja+merge

--- a/askama_warp/_typos.toml
+++ b/askama_warp/_typos.toml
@@ -1,0 +1,1 @@
+../_typos.toml

--- a/askama_warp/clippy.toml
+++ b/askama_warp/clippy.toml
@@ -1,0 +1,1 @@
+../clippy.toml

--- a/askama_warp/deny.toml
+++ b/askama_warp/deny.toml
@@ -1,0 +1,1 @@
+../deny.toml

--- a/askama_warp/src/lib.rs
+++ b/askama_warp/src/lib.rs
@@ -1,0 +1,13 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![no_std]
+#![doc = include_str!("../README.md")]
+
+#[cfg(not(docsrs))]
+compile_error!(
+    "\
+    Integration crates like `askama_warp` were removed from askama 0.13.\n\
+    Useful information can be found in our upgrade guide \
+    <https://askama.readthedocs.io/en/v0.13.0/upgrading.html>, \
+    and in our blog post <https://blog.guillaume-gomez.fr/articles/2025-03-19+Askama+and+Rinja+merge>.\
+    "
+);

--- a/askama_warp/tomlfmt.toml
+++ b/askama_warp/tomlfmt.toml
@@ -1,0 +1,1 @@
+../tomlfmt.toml


### PR DESCRIPTION
Many users don't depend on `askama` directly, but use e.g. `askama_axum` instead. They may never notice that a new askama version was released, because e.g. dependabot won't tell them.