### PR TITLE
Update to more current rust version on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,8 +6,14 @@ build:
   os: ubuntu-lts-latest
   tools:
     python: "3.12"
-    rust: "latest"
   commands:
+    # Install a current version of rust
+    - asdf install rust 1.86.0
+    - asdf global rust 1.86.0
+
+    # proc-macro2 v1.0.95 expects at least nightly-2025-04-16.
+    - cargo update --package proc-macro2 --precise 1.0.94
+
     # Generate "book/theme/index.hbs" as "skeleton" of the generated pages.
     - book/update-theme.py
     # Install mdbook.


### PR DESCRIPTION
Right now, our documentation fails to build on readthedocs, see e.g. <https://app.readthedocs.org/projects/askama/builds/27887854/>

Our documentation needs nightly features `doc_cfg`, `doc_auto_cfg` to build. Instead of using the nightly channel, which is not available on readthedocs.org, we opt in to nightly features by setting the environment variable `RUSTC_BOOTSTRAP` to `1`. This gives on unstable features in a stable channel.

Our dependency `proc-macro2` tests if opting-in to unstable feature is possible, and if so, it expects that it runs on a quite recent `nightly` release. The newest rust version that is available out-of-the-box on readthedocs is rust 1.82, which is not *that* recent anymore, being released on 2024-08-30.

This PR makes use of the readly configured tool `asdf` to select a more recent rust version semi-manually.