### PR TITLE
generator: remove invisible group from output

### DIFF
--- a/askama_derive/src/lib.rs
+++ b/askama_derive/src/lib.rs
@@ -23,7 +23,7 @@ use parser::{Parsed, ascii_str, strip_common};
 use proc_macro::TokenStream as TokenStream12;
 #[cfg(feature = "__standalone")]
 use proc_macro2::TokenStream as TokenStream12;
-use proc_macro2::{Delimiter, Group, Span, TokenStream, TokenTree};
+use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned};
 use rustc_hash::FxBuildHasher;
 
@@ -239,7 +239,6 @@ pub fn derive_template(input: TokenStream12) -> TokenStream12 {
         buf.into_string().parse().unwrap()
     };
 
-    let ts = TokenTree::Group(Group::new(Delimiter::None, ts));
     let ts = if let Some(crate_name) = crate_name {
         quote! {
             const _: () = {

--- a/askama_derive/src/tests.rs
+++ b/askama_derive/src/tests.rs
@@ -1169,3 +1169,16 @@ fn test_with_config() {
         r#"#[template(config = "empty_test_config.toml")]"#,
     );
 }
+
+#[test]
+#[cfg(feature = "__standalone")]
+fn test_generated_with_error() {
+    // Ensure that the generated code on errors can still be parsed by syn.
+    let ts = quote::quote! {
+        #[derive(Template)]
+        #[template(ext = "txt", source = "test {#")]
+        struct HelloWorld;
+    };
+    let ts = crate::derive_template(ts);
+    let _: syn::File = syn::parse2(ts).unwrap();
+}


### PR DESCRIPTION
The generated `TokenStream` gets parsed correctly by `rustc`, but fails to be parsed by `syn` in some circumstances. E.g. the template syntax `test {#` lets the playground crash.

This PR removes the invisible group.