### PR TITLE
feat: add caller pattern from jinja 

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -85,9 +85,9 @@ struct Generator<'a, 'h> {
     /// Used in blocks to check if we are inside a filter block.
     is_in_filter_block: usize,
     /// Set of called macros we are currently in. Used to prevent (indirect) recursions.
-    seen_macros: Vec<(&'a Macro<'a>, Option<FileInfo<'a>>)>,
-    /// Set of callers to forward into the macro.
-    current_caller: Option<&'a Call<'a>>,
+    seen_callers: Vec<(&'a Call<'a>, &'a Macro<'a>, Option<FileInfo<'a>>)>,
+    /// the active caller within the macro.
+    active_caller: Option<&'a Call<'a>>,
 }
 
 impl<'a, 'h> Generator<'a, 'h> {
@@ -112,8 +112,8 @@ impl<'a, 'h> Generator<'a, 'h> {
                 ..Default::default()
             },
             is_in_filter_block,
-            seen_macros: Vec::new(),
-            current_caller: None,
+            seen_callers: Vec::new(),
+            active_caller: None,
         }
     }
 

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -87,7 +87,7 @@ struct Generator<'a, 'h> {
     /// Set of called macros we are currently in. Used to prevent (indirect) recursions.
     seen_macros: Vec<(&'a Macro<'a>, Option<FileInfo<'a>>)>,
     /// Set of callers to forward into the macro.
-    seen_callers: Vec<&'a Call<'a>>,
+    current_caller: Option<&'a Call<'a>>,
 }
 
 impl<'a, 'h> Generator<'a, 'h> {
@@ -113,7 +113,7 @@ impl<'a, 'h> Generator<'a, 'h> {
             },
             is_in_filter_block,
             seen_macros: Vec::new(),
-            seen_callers: Vec::new(),
+            current_caller: None,
         }
     }
 

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -86,6 +86,8 @@ struct Generator<'a, 'h> {
     is_in_filter_block: usize,
     /// Set of called macros we are currently in. Used to prevent (indirect) recursions.
     seen_macros: Vec<(&'a Macro<'a>, Option<FileInfo<'a>>)>,
+    /// Set of called macros we are currently associated with a call.
+    seen_call_macro: Vec<&'a Macro<'a>>,
 }
 
 impl<'a, 'h> Generator<'a, 'h> {
@@ -111,6 +113,7 @@ impl<'a, 'h> Generator<'a, 'h> {
             },
             is_in_filter_block,
             seen_macros: Vec::new(),
+            seen_call_macro: Vec::new(),
         }
     }
 

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use std::str;
 use std::sync::Arc;
 
-use parser::node::{Macro, Whitespace};
+use parser::node::{Call, Macro, Whitespace};
 use parser::{
     CharLit, Expr, FloatKind, IntKind, MAX_RUST_KEYWORD_LEN, Num, RUST_KEYWORDS, StrLit, WithSpan,
 };
@@ -86,8 +86,8 @@ struct Generator<'a, 'h> {
     is_in_filter_block: usize,
     /// Set of called macros we are currently in. Used to prevent (indirect) recursions.
     seen_macros: Vec<(&'a Macro<'a>, Option<FileInfo<'a>>)>,
-    /// Set of called macros we are currently associated with a call.
-    seen_call_macro: Vec<&'a Macro<'a>>,
+    /// Set of callers to forward into the macro.
+    seen_callers: Vec<&'a Call<'a>>,
 }
 
 impl<'a, 'h> Generator<'a, 'h> {
@@ -113,7 +113,7 @@ impl<'a, 'h> Generator<'a, 'h> {
             },
             is_in_filter_block,
             seen_macros: Vec::new(),
-            seen_call_macro: Vec::new(),
+            seen_callers: Vec::new(),
         }
     }
 

--- a/askama_derive/src/generator/node.rs
+++ b/askama_derive/src/generator/node.rs
@@ -612,6 +612,7 @@ impl<'a> Generator<'a, '_> {
             scope,
             name,
             ref args,
+            ws2,
             ..
         } = **call;
 
@@ -776,7 +777,7 @@ impl<'a> Generator<'a, '_> {
             buf.write('}');
             Ok(size_hint)
         })?;
-        self.prepare_ws(ws1);
+        self.prepare_ws(ws2);
         self.seen_callers.pop();
         self.active_caller = None;
         Ok(size_hint)

--- a/askama_derive/src/generator/node.rs
+++ b/askama_derive/src/generator/node.rs
@@ -1127,10 +1127,14 @@ impl<'a> Generator<'a, '_> {
                 ctx: &Context<'a>,
                 expected: usize,
                 found: usize,
+                name: &str,
             ) -> Result<(), CompileError> {
                 if expected != found {
                     Err(ctx.generate_error(
-                        format!("expected `{}` argument, found `{}`", expected, found),
+                        format!(
+                            "expected {expected} argument{} in `{name}`, found {found}",
+                            if expected != 1 { "s" } else { "" }
+                        ),
                         s.span(),
                     ))
                 } else {
@@ -1138,11 +1142,11 @@ impl<'a> Generator<'a, '_> {
                 }
             }
             if ***path == Expr::Var("super") {
-                check_num_args(s, ctx, 0, expr_args.len())?;
+                check_num_args(s, ctx, 0, expr_args.len(), "super")?;
                 return self.write_block(ctx, buf, None, ws, s.span());
             } else if ***path == Expr::Var("caller") {
                 let def = self.active_caller.ok_or_else(|| {
-                    ctx.generate_error(format_args!("block is not defined for caller"), s.span())
+                    ctx.generate_error(format_args!("block is not defined for `caller`"), s.span())
                 })?;
                 self.active_caller = None;
                 self.handle_ws(ws);
@@ -1151,7 +1155,7 @@ impl<'a> Generator<'a, '_> {
                     buf.write('{');
                     this.prepare_ws(def.ws1);
                     let mut value = Buffer::new();
-                    check_num_args(s, ctx, def.caller_args.len(), expr_args.len())?;
+                    check_num_args(s, ctx, def.caller_args.len(), expr_args.len(), "caller")?;
                     for (index, arg) in def.caller_args.iter().enumerate() {
                         match expr_args.get(index) {
                             Some(expr) => {

--- a/askama_derive/src/generator/node.rs
+++ b/askama_derive/src/generator/node.rs
@@ -1122,7 +1122,6 @@ impl<'a> Generator<'a, '_> {
                 let def = self.seen_callers.last().ok_or_else(|| {
                     ctx.generate_error(format_args!("block is not defined for caller"), s.span())
                 })?;
-                //self.flush_ws(ws); // Cannot handle_ws() here: whitespace from macro definition comes first
                 let size_hint = self.push_locals(|this| {
                     this.write_buf_writable(ctx, buf)?;
                     buf.write('{');
@@ -1131,6 +1130,7 @@ impl<'a> Generator<'a, '_> {
                     for (index, arg) in def.caller_args.iter().enumerate() {
                         match expr_args.get(index) {
                             Some(expr) => {
+                                value.clear();
                                 match &**expr {
                                     // If `expr` is already a form of variable then
                                     // don't reintroduce a new variable. This is
@@ -1154,7 +1154,6 @@ impl<'a> Generator<'a, '_> {
                                     // multiple times, e.g. in the case of macro
                                     // parameters being used multiple times.
                                     _ => {
-                                        value.clear();
                                         let (before, after) = if !is_copyable(expr) {
                                             ("&(", ")")
                                         } else {

--- a/askama_derive/src/generator/node.rs
+++ b/askama_derive/src/generator/node.rs
@@ -1177,7 +1177,7 @@ impl<'a> Generator<'a, '_> {
                             }
                             None => {
                                 return Err(ctx.generate_error(
-                                    format_args!("missing `{arg}` argument"),
+                                    format_args!("missing `{arg}` argument in `caller`"),
                                     s.span(),
                                 ));
                             }

--- a/askama_derive/src/generator/node.rs
+++ b/askama_derive/src/generator/node.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::collections::hash_map::{Entry, HashMap};
-use std::fmt::{self, Write};
+use std::fmt::{self, Debug, Write};
 use std::mem;
 
 use parser::node::{
@@ -96,7 +96,7 @@ impl<'a> Generator<'a, '_> {
                     self.write_comment(comment);
                 }
                 Node::Expr(ws, ref val) => {
-                    self.write_expr(ws, val);
+                    size_hint += self.write_expr(ctx, buf, ws, val)?;
                 }
                 Node::Let(ref l) => {
                     self.write_let(ctx, buf, l)?;
@@ -612,18 +612,10 @@ impl<'a> Generator<'a, '_> {
             scope,
             name,
             ref args,
-            ref block,
+            ..
         } = **call;
-        if name == "super" {
-            return self.write_block(ctx, buf, None, ws, call.span());
-        }
 
-        let (def, own_ctx) = if name == "caller" {
-            let def = self.seen_call_macro.last().ok_or_else(|| {
-                ctx.generate_error(format_args!("block is not defined for caller"), call.span())
-            })?;
-            (*def, ctx)
-        } else if let Some(s) = scope {
+        let (def, own_ctx) = if let Some(s) = scope {
             let path = ctx.imports.get(s).ok_or_else(|| {
                 ctx.generate_error(format_args!("no import found for scope {s:?}"), call.span())
             })?;
@@ -657,9 +649,7 @@ impl<'a> Generator<'a, '_> {
         } else {
             self.seen_macros.push((def, ctx.file_info_of(call.span())));
         }
-        if let Some(macr) = block {
-            self.seen_call_macro.push(macr);
-        }
+        self.seen_callers.push(call);
         self.flush_ws(ws); // Cannot handle_ws() here: whitespace from macro definition comes first
         let size_hint = self.push_locals(|this| {
             macro_call_ensure_arg_count(call, def, ctx)?;
@@ -783,9 +773,7 @@ impl<'a> Generator<'a, '_> {
         })?;
         self.prepare_ws(ws);
         self.seen_macros.pop();
-        if let Some(_macr) = block {
-            self.seen_call_macro.pop();
-        }
+        self.seen_callers.pop();
         Ok(size_hint)
     }
 
@@ -1115,17 +1103,108 @@ impl<'a> Generator<'a, '_> {
         Ok(size_hint)
     }
 
-    fn write_expr(&mut self, ws: Ws, s: &'a WithSpan<'a, Expr<'a>>) {
+    fn write_expr(
+        &mut self,
+        ctx: &Context<'a>,
+        buf: &mut Buffer,
+        ws: Ws,
+        s: &'a WithSpan<'a, Expr<'a>>,
+    ) -> Result<usize, CompileError> {
+        if let Expr::Call {
+            ref path,
+            args: expr_args,
+            ..
+        } = &**s
+        {
+            if ***path == Expr::Var("super") {
+                return self.write_block(ctx, buf, None, ws, s.span());
+            } else if ***path == Expr::Var("caller") {
+                let def = self.seen_callers.last().ok_or_else(|| {
+                    ctx.generate_error(format_args!("block is not defined for caller"), s.span())
+                })?;
+                //self.flush_ws(ws); // Cannot handle_ws() here: whitespace from macro definition comes first
+                let size_hint = self.push_locals(|this| {
+                    this.write_buf_writable(ctx, buf)?;
+                    buf.write('{');
+                    this.prepare_ws(def.ws1);
+                    let mut value = Buffer::new();
+                    for (index, arg) in def.caller_args.iter().enumerate() {
+                        match expr_args.get(index) {
+                            Some(expr) => {
+                                match &**expr {
+                                    // If `expr` is already a form of variable then
+                                    // don't reintroduce a new variable. This is
+                                    // to avoid moving non-copyable values.
+                                    Expr::Var(name) if *name != "self" => {
+                                        let var = this.locals.resolve_or_self(name);
+                                        this.locals
+                                            .insert(Cow::Borrowed(arg), LocalMeta::with_ref(var));
+                                    }
+                                    Expr::Attr(obj, attr) => {
+                                        let mut attr_buf = Buffer::new();
+                                        this.visit_attr(ctx, &mut attr_buf, obj, attr)?;
+
+                                        let attr = attr_buf.into_string();
+                                        let var = this.locals.resolve(&attr).unwrap_or(attr);
+                                        this.locals
+                                            .insert(Cow::Borrowed(arg), LocalMeta::with_ref(var));
+                                    }
+                                    // Everything else still needs to become variables,
+                                    // to avoid having the same logic be executed
+                                    // multiple times, e.g. in the case of macro
+                                    // parameters being used multiple times.
+                                    _ => {
+                                        value.clear();
+                                        let (before, after) = if !is_copyable(expr) {
+                                            ("&(", ")")
+                                        } else {
+                                            ("", "")
+                                        };
+                                        value.write(this.visit_expr_root(ctx, expr)?);
+                                        // We need to normalize the arg to write it, thus we need to add it to
+                                        // locals in the normalized manner
+                                        let normalized_arg = normalize_identifier(arg);
+                                        buf.write(format_args!(
+                                            "let {} = {before}{value}{after};",
+                                            normalized_arg
+                                        ));
+                                        this.locals
+                                            .insert_with_default(Cow::Borrowed(normalized_arg));
+                                    }
+                                }
+                            }
+                            None => {
+                                return Err(ctx.generate_error(
+                                    format_args!("missing `{arg}` argument"),
+                                    s.span(),
+                                ));
+                            }
+                        }
+                    }
+
+                    let mut size_hint = this.handle(ctx, &def.nodes, buf, AstLevel::Nested)?;
+                    this.flush_ws(def.ws2);
+                    size_hint += this.write_buf_writable(ctx, buf)?;
+                    buf.write('}');
+                    Ok(size_hint)
+                })?;
+                self.prepare_ws(ws);
+                return Ok(size_hint);
+            }
+        }
+
         self.handle_ws(ws);
         let items = if let Expr::Concat(exprs) = &**s {
             exprs
         } else {
             std::slice::from_ref(s)
         };
+
         for s in items {
             self.buf_writable
                 .push(compile_time_escape(s, self.input.escaper).unwrap_or(Writable::Expr(s)));
         }
+        Ok(0)
     }
 
     // Write expression buffer and empty

--- a/askama_parser/src/lib.rs
+++ b/askama_parser/src/lib.rs
@@ -1267,6 +1267,16 @@ const KWS_PARSER: &[&[[AsciiChar; MAX_RUST_RAW_KEYWORD_LEN]]; MAX_RUST_KEYWORD_L
         result[result.len() - 1] = AsciiStr::new_sized("r#union");
         result
     };
+    const KW6: &[[AsciiChar; MAX_RUST_RAW_KEYWORD_LEN]] = &{
+        let mut result = [AsciiStr::new_sized("r#"); RUST_KEYWORDS[6].len() + 1];
+        let mut i = 0;
+        while i < RUST_KEYWORDS[6].len() {
+            result[i] = RUST_KEYWORDS[6][i];
+            i += 1;
+        }
+        result[result.len() - 1] = AsciiStr::new_sized("r#caller");
+        result
+    };
 
     [
         RUST_KEYWORDS[0],
@@ -1275,7 +1285,7 @@ const KWS_PARSER: &[&[[AsciiChar; MAX_RUST_RAW_KEYWORD_LEN]]; MAX_RUST_KEYWORD_L
         RUST_KEYWORDS[3],
         KW4,
         KW5,
-        RUST_KEYWORDS[6],
+        KW6,
         RUST_KEYWORDS[7],
         RUST_KEYWORDS[8],
     ]
@@ -1495,6 +1505,7 @@ mod test {
 
     #[test]
     fn test_is_rust_keyword() {
+        assert!(is_rust_keyword("caller"));
         assert!(is_rust_keyword("super"));
         assert!(is_rust_keyword("become"));
         assert!(!is_rust_keyword("supeeeer"));

--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -881,14 +881,36 @@ pub struct Call<'a> {
     pub scope: Option<&'a str>,
     pub name: &'a str,
     pub args: Vec<WithSpan<'a, Expr<'a>>>,
+    pub block: Option<Macro<'a>>,
 }
 
 impl<'a> Call<'a> {
     fn parse(i: &mut &'a str, s: &State<'_, '_>) -> ParseResult<'a, WithSpan<'a, Self>> {
-        let start = *i;
+        let start_s = *i;
+        let parameters = |i: &mut _| -> ParseResult<'_, Option<Vec<&str>>> {
+            let args = opt(preceded(
+                '(',
+                (
+                    opt(terminated(separated(0.., ws(identifier), ','), opt(','))),
+                    ws(opt(')')),
+                ),
+            ))
+            .parse_next(i)?;
+
+            match args {
+                Some((args, Some(_))) => Ok(args),
+                Some((_, None)) => Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+                    "expected `)` to close call argument list",
+                    *i,
+                ))),
+                None => Ok(None),
+            }
+        };
+
         let mut p = (
             opt(Whitespace::parse),
             ws(keyword("call")),
+            parameters,
             cut_node(
                 Some("call"),
                 (
@@ -899,17 +921,50 @@ impl<'a> Call<'a> {
                 ),
             ),
         );
-        let (pws, _, (scope, name, args, nws)) = p.parse_next(i)?;
+        let (pws, _, call_args, (scope, name, args, nws)) = p.parse_next(i)?;
         let scope = scope.map(|(scope, _)| scope);
         let args = args.unwrap_or_default();
+
         Ok(WithSpan::new(
             Self {
                 ws: Ws(pws, nws),
                 scope,
                 name,
                 args,
+                block: match call_args {
+                    Some(args) => {
+                        let mut end = cut_node(
+                            Some("call"),
+                            (
+                                |i: &mut _| s.tag_block_end(i),
+                                |i: &mut _| Node::many(i, s),
+                                cut_node(
+                                    Some("call"),
+                                    (
+                                        |i: &mut _| {
+                                            check_block_start(i, start_s, s, "call", "endcall")
+                                        },
+                                        opt(Whitespace::parse),
+                                        end_node("call", "endcall"),
+                                        opt(Whitespace::parse),
+                                    ),
+                                ),
+                            ),
+                        );
+
+                        let (_, nodes, (_, pws2, _, nws2)) = end.parse_next(i)?;
+                        Some(Macro {
+                            ws1: Ws(pws, pws2),
+                            name: "", // this macro is not resolved wtih a name
+                            args: args.iter().map(|v| (*v, None)).collect(),
+                            nodes,
+                            ws2: Ws(pws2, nws2),
+                        })
+                    }
+                    None => None,
+                },
             },
-            start,
+            start_s,
         ))
     }
 }

--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -877,12 +877,11 @@ impl<'a> Import<'a> {
 
 #[derive(Debug, PartialEq)]
 pub struct Call<'a> {
-    pub ws: Ws,
+    pub ws1: Ws,
     pub caller_args: Vec<&'a str>,
     pub scope: Option<&'a str>,
     pub name: &'a str,
     pub args: Vec<WithSpan<'a, Expr<'a>>>,
-    pub ws1: Ws,
     pub nodes: Vec<Node<'a>>,
     pub ws2: Ws,
 }
@@ -947,12 +946,11 @@ impl<'a> Call<'a> {
 
         Ok(WithSpan::new(
             Self {
-                ws: Ws(pws, nws),
+                ws1: Ws(pws, nws),
                 caller_args: call_args.unwrap_or_default(),
                 scope,
                 name,
                 args,
-                ws1: Ws(pws, pws2),
                 nodes,
                 ws2: Ws(pws2, nws2),
             },

--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -937,7 +937,6 @@ You can use the content in the call block directly inside the macro by using `{{
     This is a simple dialog rendered by using a macro and
     a call block.
 {% endcall %}
-
 ```
 
 Here is an example with a call block using arguments:

--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -921,9 +921,7 @@ Then if you don't pass a value for this argument, its default value will be used
 
 ### Call
 
-you can specify a block for a call to be passed down as used as apart of a macro. For this case 
-a block is denoted by `{% call(args) macro() %}`, ending with `{% endcall %}`. the callee is denoted by
-`{{caller()}}`.
+You can use the content in the call block directly inside the macro by using `{{ caller() }}`:
 
 ```jinja
 {% macro render_dialog(title, class='dialog') -%}

--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -940,7 +940,7 @@ You can use the content in the call block directly inside the macro by using `{{
 
 ```
 
-here is an example with a call block using arguments:
+Here is an example with a call block using arguments:
 
 ```jinja
 {% macro dump_users(users) -%}

--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -374,7 +374,7 @@ Here's an example child template:
 {% block content %}
   <h1>Index</h1>
   <p>Hello, world!</p>
-  {% call super() %}
+  {{ super() }}
 {% endblock %}
 ```
 
@@ -830,7 +830,7 @@ struct Item<'a> {
 
 You can define macros within your template by using `{% macro name(args) %}`, ending with `{% endmacro %}`.
 
-You can then call it with `{% call name(args) %}`:
+You can then call it with `{% call name(args) %}`, ending with `{% endcall %}`:
 
 ```jinja
 {% macro heading(arg) %}
@@ -839,7 +839,7 @@ You can then call it with `{% call name(args) %}`:
 
 {% endmacro %}
 
-{% call heading(s) %}
+{% call heading(s) %} {% endcall %}
 ```
 
 You can place macros in a separate file and use them in your templates by using `{% import %}`:
@@ -847,7 +847,7 @@ You can place macros in a separate file and use them in your templates by using 
 ```jinja
 {%- import "macro.html" as scope -%}
 
-{% call scope::heading(s) %}
+{% call scope::heading(s) %} {% endcall %}
 ```
 
 You can optionally specify the name of the macro in `endmacro`:
@@ -865,19 +865,19 @@ You can also specify arguments by their name (as defined in the macro):
 
 {% endmacro %}
 
-{% call heading(bold="something", arg="title") %}
+{% call heading(bold="something", arg="title") %} {% endcall%}
 ```
 
 You can use whitespace characters around `=`:
 
 ```jinja
-{% call heading(bold = "something", arg = "title") %}
+{% call heading(bold = "something", arg = "title") %}{% endcall %}
 ```
 
 You can mix named and non-named arguments when calling a macro:
 
 ```
-{% call heading("title", bold="something") %}
+{% call heading("title", bold="something") %}{% endcall %}
 ```
 
 However please note that named arguments must always come **last**.
@@ -889,16 +889,16 @@ be used for a non-named argument, it will error:
 {% macro heading(arg1, arg2, arg3, arg4) %}
 {% endmacro %}
 
-{% call heading("something", "b", arg4="ah", arg2="title") %}
+{% call heading("something", "b", arg4="ah", arg2="title") %}{% endcall %}
 ```
 
 In here it's invalid because `arg2` is the second argument and would be used by
 `"b"`. So either you replace `"b"` with `arg3="b"` or you pass `"title"` before:
 
 ```jinja
-{% call heading("something", arg3="b", arg4="ah", arg2="title") %}
+{% call heading("something", arg3="b", arg4="ah", arg2="title") %}{% endcall %}
 {# Equivalent of: #}
-{% call heading("something", "title", "b", arg4="ah") %}
+{% call heading("something", "title", "b", arg4="ah") %}{% endcall %}
 ```
 
 ### Default value
@@ -914,24 +914,23 @@ Then if you don't pass a value for this argument, its default value will be used
 
 ```jinja
 {# We only specify `arg1`, so `arg2` will be "something" #}
-{% call heading(1) %}
+{% call heading(1) %} {% endcall %}
 {# We specify both `arg1` and `arg2` so no default value is used #}
-{% call heading(1, 2) %}
+{% call heading(1, 2) %} {% endcall %}
 ```
 
 ### Call
 
 you can specify a block for a call to be passed down as used as apart of a macro. For this case 
-a block is denoted by `{% call(args) macro() %}`, ending with `{% endcall %}`. for a call with no args it's 
-denoted by `{% call() macro() %}`, ending with `{% endcall %}`. Inside a macro, the `caller()` macro 
-is called to pull in the block from the caller.
+a block is denoted by `{% call(args) macro() %}`, ending with `{% endcall %}`. the callee is denoted by
+`{{caller()}}`.
 
 ```jinja
 {% macro render_dialog(title, class='dialog') -%}
     <div class="{{ class }}">
         <h2>{{ title }}</h2>
         <div class="contents">
-            {% call caller() %}
+            {{ caller() }}
         </div>
     </div>
 {%- endmacro %}
@@ -949,7 +948,7 @@ here is an example with a call block using arguments:
 {% macro dump_users(users) -%}
     <ul>
     {%- for user in users %}
-        <li><p>{{ user.username }}</p>{% call caller(user) %}</li>
+        <li><p>{{ user.username }}</p>{{ caller(user) }}</li>
     {%- endfor %}
     </ul>
 {%- endmacro %}

--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -839,7 +839,7 @@ You can then call it with `{% call name(args) %}`, ending with `{% endcall %}`:
 
 {% endmacro %}
 
-{% call heading(s) %} {% endcall %}
+{% call heading(s) %}{% endcall %}
 ```
 
 You can place macros in a separate file and use them in your templates by using `{% import %}`:
@@ -847,7 +847,7 @@ You can place macros in a separate file and use them in your templates by using 
 ```jinja
 {%- import "macro.html" as scope -%}
 
-{% call scope::heading(s) %} {% endcall %}
+{% call scope::heading(s) %}{% endcall %}
 ```
 
 You can optionally specify the name of the macro in `endmacro`:
@@ -865,7 +865,7 @@ You can also specify arguments by their name (as defined in the macro):
 
 {% endmacro %}
 
-{% call heading(bold="something", arg="title") %} {% endcall%}
+{% call heading(bold="something", arg="title") %}{% endcall%}
 ```
 
 You can use whitespace characters around `=`:
@@ -914,9 +914,9 @@ Then if you don't pass a value for this argument, its default value will be used
 
 ```jinja
 {# We only specify `arg1`, so `arg2` will be "something" #}
-{% call heading(1) %} {% endcall %}
+{% call heading(1) %}{% endcall %}
 {# We specify both `arg1` and `arg2` so no default value is used #}
-{% call heading(1, 2) %} {% endcall %}
+{% call heading(1, 2) %}{% endcall %}
 ```
 
 ### Call
@@ -958,7 +958,6 @@ Here is an example with a call block using arguments:
         <dd>{{ user.description }}</dd>
     </dl>
 {% endcall %}
-
 ```
 
 ## Calling Rust macros

--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -919,6 +919,52 @@ Then if you don't pass a value for this argument, its default value will be used
 {% call heading(1, 2) %}
 ```
 
+### Call
+
+you can specify a block for a call to be passed down as used as apart of a macro. For this case 
+a block is denoted by `{% call(args) macro() %}`, ending with `{% endcall %}`. for a call with no args it's 
+denoted by `{% call() macro() %}`, ending with `{% endcall %}`. Inside a macro, the `caller()` macro 
+is called to pull in the block from the caller.
+
+```jinja
+{% macro render_dialog(title, class='dialog') -%}
+    <div class="{{ class }}">
+        <h2>{{ title }}</h2>
+        <div class="contents">
+            {% call caller() %}
+        </div>
+    </div>
+{%- endmacro %}
+
+{% call() render_dialog('Hello World') %}
+    This is a simple dialog rendered by using a macro and
+    a call block.
+{% endcall %}
+
+```
+
+here is an example with a call block using arguments:
+
+```jinja
+{% macro dump_users(users) -%}
+    <ul>
+    {%- for user in users %}
+        <li><p>{{ user.username }}</p>{% call caller(user) %}</li>
+    {%- endfor %}
+    </ul>
+{%- endmacro %}
+
+{% call(user) dump_users(list_of_user) %}
+    <dl>
+        <dt>Realname</dt>
+        <dd>{{ user.realname }}</dd>
+        <dt>Description</dt>
+        <dd>{{ user.description }}</dd>
+    </dl>
+{% endcall %}
+
+```
+
 ## Calling Rust macros
 
 It is possible to call rust macros directly in your templates:

--- a/examples/actix-web-app/templates/greet.html
+++ b/examples/actix-web-app/templates/greet.html
@@ -39,5 +39,5 @@
         </a>
     </h2>
 
-    {%- call lang_select("greeting_handler", name|urlencode|fmt("?name={}")) -%}
+    {%- call lang_select("greeting_handler", name|urlencode|fmt("?name={}")) -%}{%- endcall -%}
 {%- endblock -%}

--- a/examples/actix-web-app/templates/index.html
+++ b/examples/actix-web-app/templates/index.html
@@ -85,5 +85,5 @@
         The called macro is defined in base template "_layout.html",
         and used to display the language selection footer.
     ~#}
-    {%- call lang_select("index_handler", "") -%}
+    {%- call lang_select("index_handler", "") -%}{%- endcall -%}
 {%- endblock -%}

--- a/examples/axum-app/templates/greet.html
+++ b/examples/axum-app/templates/greet.html
@@ -39,5 +39,5 @@
         </a>
     </h2>
 
-    {%- call lang_select("greet-me", name|urlencode|fmt("?name={}")) -%}
+    {%- call lang_select("greet-me", name|urlencode|fmt("?name={}")) -%}{%- endcall -%}
 {%- endblock -%}

--- a/examples/axum-app/templates/index.html
+++ b/examples/axum-app/templates/index.html
@@ -80,5 +80,5 @@
         The called macro is defined in base template "_layout.html",
         and used to display the language selection footer.
     ~#}
-    {%- call lang_select("index") -%}
+    {%- call lang_select("index") -%}{%- endcall -%}
 {%- endblock -%}

--- a/examples/poem-app/templates/greet.html
+++ b/examples/poem-app/templates/greet.html
@@ -39,5 +39,5 @@
         </a>
     </h2>
 
-    {%- call lang_select("greet-me", name|urlencode|fmt("?name={}")) -%}
+    {%- call lang_select("greet-me", name|urlencode|fmt("?name={}")) -%}{%- endcall -%}
 {%- endblock -%}

--- a/examples/poem-app/templates/index.html
+++ b/examples/poem-app/templates/index.html
@@ -80,5 +80,5 @@
         The called macro is defined in base template "_layout.html",
         and used to display the language selection footer.
     ~#}
-    {%- call lang_select("index") -%}
+    {%- call lang_select("index") -%}{%- endcall -%}
 {%- endblock -%}

--- a/examples/rocket-app/templates/greet.html
+++ b/examples/rocket-app/templates/greet.html
@@ -39,5 +39,5 @@
         </a>
     </h2>
 
-    {%- call lang_select("greet-me", name|urlencode|fmt("?name={}")) -%}
+    {%- call lang_select("greet-me", name|urlencode|fmt("?name={}")) -%}{%- endcall -%}
 {%- endblock -%}

--- a/examples/rocket-app/templates/index.html
+++ b/examples/rocket-app/templates/index.html
@@ -80,5 +80,5 @@
         The called macro is defined in base template "_layout.html",
         and used to display the language selection footer.
     ~#}
-    {%- call lang_select("index") -%}
+    {%- call lang_select("index") -%}{%- endcall -%}
 {%- endblock -%}

--- a/examples/salvo-app/templates/greet.html
+++ b/examples/salvo-app/templates/greet.html
@@ -39,5 +39,5 @@
         </a>
     </h2>
 
-    {%- call lang_select("greet-me", name|urlencode|fmt("?name={}")) -%}
+    {%- call lang_select("greet-me", name|urlencode|fmt("?name={}")) -%}{%- endcall -%}
 {%- endblock -%}

--- a/examples/salvo-app/templates/index.html
+++ b/examples/salvo-app/templates/index.html
@@ -80,5 +80,5 @@
         The called macro is defined in base template "_layout.html",
         and used to display the language selection footer.
     ~#}
-    {%- call lang_select("index") -%}
+    {%- call lang_select("index") -%}{%- endcall -%}
 {%- endblock -%}

--- a/examples/warp-app/templates/greet.html
+++ b/examples/warp-app/templates/greet.html
@@ -39,5 +39,5 @@
         </a>
     </h2>
 
-    {%- call lang_select("greet-me", name|urlencode|fmt("?name={}")) -%}
+    {%- call lang_select("greet-me", name|urlencode|fmt("?name={}")) -%}{%- endcall -%}
 {%- endblock -%}

--- a/examples/warp-app/templates/index.html
+++ b/examples/warp-app/templates/index.html
@@ -80,5 +80,5 @@
         The called macro is defined in base template "_layout.html",
         and used to display the language selection footer.
     ~#}
-    {%- call lang_select("index") -%}
+    {%- call lang_select("index") -%}{%- endcall -%}
 {%- endblock -%}

--- a/testing/templates/deep-base.html
+++ b/testing/templates/deep-base.html
@@ -7,7 +7,7 @@
   </head>
   <body>
   {% block body %}
-    {% call libb::thrice("nav") %}
+    {% call libb::thrice("nav") %}{% endcall %}
     Copyright {{ year }}
   {% endblock %}
   </body>

--- a/testing/templates/deep-import-child.html
+++ b/testing/templates/deep-import-child.html
@@ -1,4 +1,4 @@
 {%- import "nested-macro.html" as libi -%}
 {%- macro parent() -%}
-    {% call libi::parent() %}
+    {% call libi::parent() %}{% endcall %}
 {%- endmacro -%}

--- a/testing/templates/deep-import-parent.html
+++ b/testing/templates/deep-import-parent.html
@@ -1,2 +1,2 @@
 {%- import "deep-import-child.html" as libj -%}
-{% call libj::parent() %}
+{% call libj::parent() %}{% endcall %}

--- a/testing/templates/deep-kid.html
+++ b/testing/templates/deep-kid.html
@@ -6,5 +6,5 @@
 {% endblock %}
 
 {% block content %}
-  {% call libk::thrice(item) %}
+  {% call libk::thrice(item) %}{% endcall %}
 {% endblock %}

--- a/testing/templates/deep-mid.html
+++ b/testing/templates/deep-mid.html
@@ -3,7 +3,7 @@
 
 {% block head %}
   {{ title }}
-  {% call super() %}
+  {{ super() }}
 {% endblock %}
 
 {% block body %}
@@ -14,7 +14,7 @@
     {% endblock %}
     </section>
     <section id="nav">
-      {% call libm::thrice("nav") %}
+      {% call libm::thrice("nav") %}{% endcall %}
     </section>
   </div>
 {% endblock %}

--- a/testing/templates/deep-nested-macro.html
+++ b/testing/templates/deep-nested-macro.html
@@ -1,2 +1,2 @@
 {%- import "nested-macro.html" as libi -%}
-{%- call libi::parent() -%}
+{%- call libi::parent() -%}{%- endcall -%}

--- a/testing/templates/fragment-mid-super.html
+++ b/testing/templates/fragment-mid-super.html
@@ -1,9 +1,9 @@
 {% extends "fragment-base.html" %}
 
 {% block body %}
-[{% call super() %}]
+[{{ super() }}]
 {% endblock %}
 
 {% block other_body %}
-({% call super() %})
+({{ super() }})
 {% endblock %}

--- a/testing/templates/fragment-nested-super.html
+++ b/testing/templates/fragment-nested-super.html
@@ -2,11 +2,11 @@
 
 {% block body %}
 <p>Hello {{ name }}!</p>
-{% call super() %}
+{{ super() }}
 {% endblock %}
 
 {% block other_body %}
 <p>Don't render me.</p>
-{% call super() %}
+{{ super() }}
 {% endblock %}
 

--- a/testing/templates/fragment-super.html
+++ b/testing/templates/fragment-super.html
@@ -2,11 +2,11 @@
 
 {% block body %}
 <p>Hello {{ name }}!</p>
-{% call super() %}
+{{ super() }}
 {% endblock %}
 
 {% block other_body %}
 <p>Don't render me.</p>
-{% call super() %}
+{{ super() }}
 {% endblock %}
 

--- a/testing/templates/if-coerce.html
+++ b/testing/templates/if-coerce.html
@@ -3,28 +3,28 @@
 {% endmacro -%}
 
 {% macro bar(b) -%}
-    {%- call foo(b) -%}
+    {%- call foo(b) -%}{%- endcall -%}
 {% endmacro -%}
 
 {% macro baz(b) -%}
-    {%- call bar(b) -%}
+    {%- call bar(b) -%}{%- endcall -%}
 {% endmacro -%}
 
 {% macro qux(b) -%}
-    {%- call baz(b) -%}
+    {%- call baz(b) -%}{%- endcall -%}
 {% endmacro -%}
 
-{%- call foo(false) -%}
-{%- call bar(true) -%}
-{%- call baz(false) -%}
-{%- call qux(true) -%}
+{%- call foo(false) -%}{%- endcall -%}
+{%- call bar(true) -%}{%- endcall -%}
+{%- call baz(false) -%}{%- endcall -%}
+{%- call qux(true) -%}{%- endcall -%}
 
-{%- call qux(true && false) -%}
-{%- call qux(false || true) -%}
+{%- call qux(true && false) -%}{%- endcall -%}
+{%- call qux(false || true) -%}{%- endcall -%}
 
-{%- call qux(self.t) -%}
-{%- call qux(self.f) -%}
-{%- call qux(self.f || self.t) -%}
+{%- call qux(self.t) -%}{%- endcall -%}
+{%- call qux(self.f) -%}{%- endcall -%}
+{%- call qux(self.f || self.t) -%}{%- endcall -%}
 
 {%- if false -%}
 if

--- a/testing/templates/import.html
+++ b/testing/templates/import.html
@@ -1,4 +1,4 @@
 
 {%- import "macro.html" as scope -%}
 
-{% call scope::thrice(s) %}
+{% call scope::thrice(s) %}{% endcall %}

--- a/testing/templates/included-macro.html
+++ b/testing/templates/included-macro.html
@@ -2,5 +2,5 @@
     Howdy, {{ name }}!
 {%- endmacro -%}
 
-{% call m(name) %}
-{% call m2(name2) %}
+{% call m(name) %}{% endcall %}
+{% call m2(name2) %}{% endcall %}

--- a/testing/templates/macro-import-str-cmp-macro.html
+++ b/testing/templates/macro-import-str-cmp-macro.html
@@ -9,5 +9,5 @@
 {% endmacro %}
 
 {% macro strcmp(s) %}
-    {%- call strcmp0(s, "bar") -%}
+    {%- call strcmp0(s, "bar") -%}{%- endcall -%}
 {% endmacro %}

--- a/testing/templates/macro-import-str-cmp.html
+++ b/testing/templates/macro-import-str-cmp.html
@@ -2,14 +2,14 @@
 
 A
 
-{%- call macros::strcmp("foo") -%}
+{%- call macros::strcmp("foo") -%}{%- endcall -%}
 
 B
 
-{%- call macros::strcmp("bar") -%}
+{%- call macros::strcmp("bar") -%}{%- endcall -%}
 
 C
 
-{%- call macros::strcmp("cat") -%}
+{%- call macros::strcmp("cat") -%}{%- endcall -%}
 
 D

--- a/testing/templates/macro-no-args.html
+++ b/testing/templates/macro-no-args.html
@@ -6,7 +6,7 @@ the best thing
 
 1
 
-{%- call empty() -%}
+{%- call empty() -%}{%- endcall -%}
 
 1
 
@@ -16,6 +16,6 @@ we've ever done
 
 11
 
-{%- call whole -%}
+{%- call whole -%}{%- endcall -%}
 
 11

--- a/testing/templates/macro-recursion-1.html
+++ b/testing/templates/macro-recursion-1.html
@@ -1,5 +1,5 @@
 {% import "macro-recursion-2.html" as next %}
 
 {% macro some_macro %}
-    {% call next::some_macro %}
+    {% call next::some_macro %}{% endcall %}
 {% endmacro %}

--- a/testing/templates/macro-recursion-2.html
+++ b/testing/templates/macro-recursion-2.html
@@ -1,5 +1,5 @@
 {% import "macro-recursion-3.html" as next %}
 
 {% macro some_macro %}
-    {% call next::some_macro %}
+    {% call next::some_macro %}{% endcall %}
 {% endmacro %}

--- a/testing/templates/macro-recursion-3.html
+++ b/testing/templates/macro-recursion-3.html
@@ -1,5 +1,5 @@
 {% import "macro-recursion-1.html" as next %}
 
 {% macro some_macro %}
-    {% call next::some_macro %}
+    {% call next::some_macro %}{% endcall %}
 {% endmacro %}

--- a/testing/templates/macro-self-arg.html
+++ b/testing/templates/macro-self-arg.html
@@ -2,4 +2,4 @@
     {{ slf.s }}
 {%- endmacro -%}
 
-{%- call my_s(self) -%}
+{%- call my_s(self) -%}{%- endcall -%}

--- a/testing/templates/macro-short-circuit.html
+++ b/testing/templates/macro-short-circuit.html
@@ -1,9 +1,9 @@
 {% macro foo(b) -%}
     {{ b }}
 {%- endmacro -%}
-{% call foo(true) -%}{% endcall %}
-{% call foo(true && true) -%}{% endcall %}
-{% call foo(true && true && true) -%}{% endcall %}
-{% call foo(false) -%}{% endcall %}
-{% call foo(false || true) -%}{% endcall %}
-{% call foo(false || false || true) -%}{% endcall %}
+{% call foo(true) -%}{% endcall -%}
+{% call foo(true && true) -%}{% endcall -%}
+{% call foo(true && true && true) -%}{% endcall -%}
+{% call foo(false) -%}{% endcall -%}
+{% call foo(false || true) -%}{% endcall -%}
+{% call foo(false || false || true) -%}{% endcall -%}

--- a/testing/templates/macro-short-circuit.html
+++ b/testing/templates/macro-short-circuit.html
@@ -1,9 +1,9 @@
 {% macro foo(b) -%}
     {{ b }}
 {%- endmacro -%}
-{% call foo(true) -%}
-{% call foo(true && true) -%}
-{% call foo(true && true && true) -%}
-{% call foo(false) -%}
-{% call foo(false || true) -%}
-{% call foo(false || false || true) -%}
+{% call foo(true) -%}{% endcall %}
+{% call foo(true && true) -%}{% endcall %}
+{% call foo(true && true && true) -%}{% endcall %}
+{% call foo(false) -%}{% endcall %}
+{% call foo(false || true) -%}{% endcall %}
+{% call foo(false || false || true) -%}{% endcall %}

--- a/testing/templates/macro.html
+++ b/testing/templates/macro.html
@@ -8,7 +8,7 @@
 
 2
 
-{%- call thrice(s) -%}
+{%- call thrice(s) -%}{%- endcall -%}
 
 3
 
@@ -20,6 +20,6 @@
 
 4
 
-{%- call twice(s) -%}
+{%- call twice(s) -%}{%- endcall -%}
 
 5

--- a/testing/templates/nested-macro-args.html
+++ b/testing/templates/nested-macro-args.html
@@ -1,9 +1,9 @@
 {%- macro outer(first) -%}
-{%- call inner(first, "second") -%}
+{%- call inner(first, "second") -%}{%- endcall -%}
 {%- endmacro -%}
 
 {%- macro inner(first, second) -%}
 {{ first }} {{ second }}
 {%- endmacro -%}
 
-{%- call outer("first") -%}
+{%- call outer("first") -%}{%- endcall -%}

--- a/testing/templates/nested-macro.html
+++ b/testing/templates/nested-macro.html
@@ -3,9 +3,9 @@
 {%- endmacro -%}
 
 {%- macro child1() -%}
-    {% call child0() %}
+    {% call child0() %}{% endcall %}
 {%- endmacro -%}
 
 {%- macro parent() -%}
-    {% call child1() %}
+    {% call child1() %}{% endcall %}
 {%- endmacro -%}

--- a/testing/templates/size-child-super.txt
+++ b/testing/templates/size-child-super.txt
@@ -1,2 +1,2 @@
 {% extends "size-parent.txt" %}
-{% block main %}{% call super() %}{% endblock %}
+{% block main %}{{ super() }}{% endblock %}

--- a/testing/tests/calls.rs
+++ b/testing/tests/calls.rs
@@ -125,7 +125,6 @@ nested
     assert_eq!(x.render().unwrap(), "nested");
 }
 
-
 #[test]
 fn test_caller_struct() {
     struct TestInput<'a> {

--- a/testing/tests/calls.rs
+++ b/testing/tests/calls.rs
@@ -114,15 +114,15 @@ fn test_caller() {
 {%- macro test() -%}
 {{- caller() -}}
 {%- endmacro -%}
-{%- call() test() -%}
+{%- call() test() %}
 nested
-{%- endcall -%}
+{% endcall -%}
 "#,
         ext = "html"
     )]
     struct CallerEmpty {}
     let x = CallerEmpty {};
-    assert_eq!(x.render().unwrap(), "nested");
+    assert_eq!(x.render().unwrap(), "\nnested\n\n");
 }
 
 #[test]

--- a/testing/tests/calls.rs
+++ b/testing/tests/calls.rs
@@ -106,6 +106,8 @@ mod test_double_attr_arg {
     }
 }
 
+// This test ensures that whitespace characters are removed when `endcall` ends
+// with `-%}`.
 #[test]
 fn test_caller() {
     #[derive(Template)]
@@ -120,9 +122,28 @@ nested
 "#,
         ext = "html"
     )]
-    struct CallerEmpty {}
-    let x = CallerEmpty {};
-    assert_eq!(x.render().unwrap(), "\nnested\n\n");
+    struct CallerEmpty;
+    assert_eq!(CallerEmpty.render().unwrap(), "\nnested\n");
+}
+
+// This test ensures that whitespace characters are NOT removed when `endcall` ends
+// with `%}`.
+#[test]
+fn test_caller2() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
+{%- macro test() -%}
+{{- caller() -}}
+{%- endmacro -%}
+{%- call() test() %}
+nested
+{% endcall %}
+"#,
+        ext = "html"
+    )]
+    struct CallerEmpty;
+    assert_eq!(CallerEmpty.render().unwrap(), "\nnested\n\n");
 }
 
 #[test]

--- a/testing/tests/calls.rs
+++ b/testing/tests/calls.rs
@@ -125,17 +125,18 @@ nested
     assert_eq!(x.render().unwrap(), "nested");
 }
 
+
 #[test]
 fn test_caller_struct() {
     struct TestInput<'a> {
-        a: &'a str, 
-        b: &'a str 
+        a: &'a str,
+        b: &'a str,
     }
     #[derive(Template)]
     #[template(
         source = r#"
 {%- macro test(a) -%}
-{{caller(a)}}
+{{- caller(a) -}}
 {%- endmacro -%}
 {%- call(value) test(a) -%}
 a: {{value.a}}
@@ -145,13 +146,10 @@ b: {{value.b}}
         ext = "txt"
     )]
     struct Tmpl<'a> {
-        a: TestInput<'a>
+        a: TestInput<'a>,
     }
     let x = Tmpl {
-        a: TestInput {
-            a: "one",
-            b: "two"
-        }
+        a: TestInput { a: "one", b: "two" },
     };
     assert_eq!(x.render().unwrap(), "a: one\nb: two");
 }
@@ -162,18 +160,18 @@ fn test_caller_args() {
     #[template(
         source = r#"
 {%- macro test() -%}
-{{-  caller("test") -}}
-{{-  caller(1) -}}
+{{~ caller("test") ~}}
+{{~ caller(1) ~}}
 {%- endmacro -%}
 {%- call(value) test() -%}
-nested {{value}}
+nested {{value}}  
 {%- endcall -%}
 "#,
         ext = "html"
     )]
     struct CallerEmpty {}
     let x = CallerEmpty {};
-    assert_eq!(x.render().unwrap(), "nested testnested 1");
+    assert_eq!(x.render().unwrap(), "nested test\nnested 1");
 }
 
 // Ensures that fields are not moved when calling a jinja macro.

--- a/testing/tests/calls.rs
+++ b/testing/tests/calls.rs
@@ -106,6 +106,45 @@ mod test_double_attr_arg {
     }
 }
 
+#[test]
+fn test_caller() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
+{%- macro test() -%}
+{%- call caller() -%}
+{%- endmacro -%}
+{%- call() test() -%}
+nested
+{%- endcall -%}
+"#,
+        ext = "html"
+    )]
+    struct CallerEmpty {}
+    let x = CallerEmpty {};
+    assert_eq!(x.render().unwrap(), "nested");
+}
+
+#[test]
+fn test_caller_args() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
+{%- macro test() -%}
+{%- call caller("test") -%}
+{%- call caller("test") -%}
+{%- endmacro -%}
+{%- call(value) test() -%}
+nested {{value}}
+{%- endcall -%}
+"#,
+        ext = "html"
+    )]
+    struct CallerEmpty {}
+    let x = CallerEmpty {};
+    assert_eq!(x.render().unwrap(), "nested testnested test");
+}
+
 // Ensures that fields are not moved when calling a jinja macro.
 #[test]
 fn test_do_not_move_fields() {

--- a/testing/tests/calls.rs
+++ b/testing/tests/calls.rs
@@ -112,7 +112,7 @@ fn test_caller() {
     #[template(
         source = r#"
 {%- macro test() -%}
-{%- call caller() -%}
+{{- caller() -}}
 {%- endmacro -%}
 {%- call() test() -%}
 nested
@@ -126,13 +126,44 @@ nested
 }
 
 #[test]
+fn test_caller_struct() {
+    struct TestInput<'a> {
+        a: &'a str, 
+        b: &'a str 
+    }
+    #[derive(Template)]
+    #[template(
+        source = r#"
+{%- macro test(a) -%}
+{{caller(a)}}
+{%- endmacro -%}
+{%- call(value) test(a) -%}
+a: {{value.a}}
+b: {{value.b}}
+{%- endcall -%}
+"#,
+        ext = "txt"
+    )]
+    struct Tmpl<'a> {
+        a: TestInput<'a>
+    }
+    let x = Tmpl {
+        a: TestInput {
+            a: "one",
+            b: "two"
+        }
+    };
+    assert_eq!(x.render().unwrap(), "a: one\nb: two");
+}
+
+#[test]
 fn test_caller_args() {
     #[derive(Template)]
     #[template(
         source = r#"
 {%- macro test() -%}
-{%- call caller("test") -%}
-{%- call caller("test") -%}
+{{-  caller("test") -}}
+{{-  caller("test") -}}
 {%- endmacro -%}
 {%- call(value) test() -%}
 nested {{value}}
@@ -159,7 +190,7 @@ no show
 {%- endif -%}
 {%- endmacro -%}
 
-{%- call package_navigation(title=title, show=true) -%}
+{%- call package_navigation(title=title, show=true) -%}{%- endcall -%}
 ",
         ext = "html"
     )]

--- a/testing/tests/calls.rs
+++ b/testing/tests/calls.rs
@@ -163,7 +163,7 @@ fn test_caller_args() {
         source = r#"
 {%- macro test() -%}
 {{-  caller("test") -}}
-{{-  caller("test") -}}
+{{-  caller(1) -}}
 {%- endmacro -%}
 {%- call(value) test() -%}
 nested {{value}}
@@ -173,7 +173,7 @@ nested {{value}}
     )]
     struct CallerEmpty {}
     let x = CallerEmpty {};
-    assert_eq!(x.render().unwrap(), "nested testnested test");
+    assert_eq!(x.render().unwrap(), "nested testnested 1");
 }
 
 // Ensures that fields are not moved when calling a jinja macro.

--- a/testing/tests/extend.rs
+++ b/testing/tests/extend.rs
@@ -14,9 +14,9 @@ fn test_macro_in_block_inheritance() {
 {%- endmacro -%}
 
 {% block header -%}
-{% call m1::twice(1) %}
-{% call m2::twice(2) %}
-{% call another(3) %}
+{% call m1::twice(1) %}{% endcall %}
+{% call m2::twice(2) %}{% endcall %}
+{% call another(3) %}{% endcall %}
 {%- endblock -%}
 "#,
         ext = "txt"

--- a/testing/tests/loops.rs
+++ b/testing/tests/loops.rs
@@ -453,7 +453,7 @@ fn test_loop_locals() {
 {% endfor -%}
 {% endmacro -%}
 
-{% call mac(bla=bla) %}
+{% call mac(bla=bla) %}{% endcall %}
 {{- bla }}"#,
         ext = "txt"
     )]

--- a/testing/tests/macro.rs
+++ b/testing/tests/macro.rs
@@ -252,7 +252,6 @@ fn test_caller_expr() {
     )]
     struct MacroCallerExpr;
     assert_eq!(MacroCallerExpr.render().unwrap(), "20 1 35\n");
-
 }
 
 #[test]
@@ -261,24 +260,41 @@ fn test_caller_in_caller() {
     #[template(
         source = r#"
         {%- macro test2() -%}
-            {{~ caller("bb") ~}}
+            {{ caller("bb") }}
         {%- endmacro -%}
         {%- macro test() -%}
-            {{~ caller("a") ~}}
+            {{ caller("a") }}
+            {%- call(b) test2() -%}
+                five: {{ b }}
+            {%~ endcall -%}
+        {%- endmacro -%}
+        {%- macro test3() -%}
+            {{ caller("cc") }}
+        {%- endmacro -%}
+        {%- macro test4() -%}
+            {{ caller("dd") }}
         {%- endmacro -%}
         {%- call(a) test() -%}
             {%- call(b) test2() -%}
                 one: {{ b }}
+            {%~ endcall -%}
+            {%- call(b) test3() -%}
+                two: {{ b }}
+                {%~ call(b) test4() -%}
+                    three: {{ b }}
+                {%~ endcall -%}
             {%- endcall -%}
-            two: {{- a -}}
-        {%- endcall -%}
+            four: {{ a }}
+        {%~ endcall -%}
         "#,
         ext = "txt"
     )]
-    struct CallerInCaller; 
-    assert_eq!(CallerInCaller.render().unwrap(), "one: bbtwo:a");
+    struct CallerInCaller;
+    assert_eq!(
+        CallerInCaller.render().unwrap(),
+        "one: bb\ntwo: cc\nthree: dd\nfour: a\nfive: bb\n"
+    );
 }
-
 
 // This test ensures that we can use declared variables as default value for
 // macro arguments.

--- a/testing/tests/macro.rs
+++ b/testing/tests/macro.rs
@@ -238,6 +238,48 @@ fn test_default_value3() {
     );
 }
 
+// This test a caller expression with expressions in the arguments.
+#[test]
+fn test_caller_expr() {
+    #[derive(Template)]
+    #[template(
+        source = "{%- macro thrice(a, b, c) -%}
+{{caller(a+10,b - 10,a+b+c)}}
+{% endmacro -%}
+{%- call(a,b,c) thrice(10,11,13) -%}{{a}} {{b}} {{c + 1}}{%- endcall -%}
+",
+        ext = "html"
+    )]
+    struct MacroCallerExpr;
+    assert_eq!(MacroCallerExpr.render().unwrap(), "20 1 35\n");
+
+}
+
+#[test]
+fn test_caller_in_caller() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
+        {%- macro test2() -%}
+            {{~ caller("bb") ~}}
+        {%- endmacro -%}
+        {%- macro test() -%}
+            {{~ caller("a") ~}}
+        {%- endmacro -%}
+        {%- call(a) test() -%}
+            {%- call(b) test2() -%}
+                one: {{ b }}
+            {%- endcall -%}
+            two: {{- a -}}
+        {%- endcall -%}
+        "#,
+        ext = "txt"
+    )]
+    struct CallerInCaller; 
+    assert_eq!(CallerInCaller.render().unwrap(), "one: bbtwo:a");
+}
+
+
 // This test ensures that we can use declared variables as default value for
 // macro arguments.
 #[test]

--- a/testing/tests/macro.rs
+++ b/testing/tests/macro.rs
@@ -106,9 +106,9 @@ fn test_named_argument() {
 {{ param1 }} {{ param2 }}
 {% endmacro -%}
 
-{%- call thrice(param1=2, param2=3) -%}
-{%- call thrice(param2=3, param1=2) -%}
-{%- call thrice(3, param2=2) -%}
+{%- call thrice(param1=2, param2=3) -%}{%- endcall -%}
+{%- call thrice(param2=3, param1=2) -%}{%- endcall -%}
+{%- call thrice(3, param2=2) -%}{%- endcall -%}
 ",
         ext = "html"
     )]
@@ -132,7 +132,7 @@ fn test_only_named_argument() {
 {{- label -}}
 {% endmacro %}
 
-{%- call button(label="hi") -%}
+{%- call button(label="hi") -%}{%- endcall -%}
 "#,
         ext = "html"
     )]
@@ -158,11 +158,11 @@ fn test_trailing_comma() {
 {%- macro button5(label ) %}
 {% endmacro %}
 
-{%- call button(label="hi" , ) -%}
-{%- call button(label="hi" ,) -%}
-{%- call button(label="hi",) -%}
-{%- call button(label="hi", ) -%}
-{%- call button(label="hi" ) -%}
+{%- call button(label="hi" , ) -%}{%- endcall -%}
+{%- call button(label="hi" ,) -%}{%- endcall -%}
+{%- call button(label="hi",) -%}{%- endcall -%}
+{%- call button(label="hi", ) -%}{%- endcall -%}
+{%- call button(label="hi" ) -%}{%- endcall -%}
 "#,
         ext = "html"
     )]
@@ -179,11 +179,11 @@ fn test_default_value() {
 {{ param1 }} {{ param2 }}
 {% endmacro -%}
 
-{%- call thrice() -%}
-{%- call thrice(param1=4) -%}
-{%- call thrice(param2=4) -%}
-{%- call thrice(param2=4, param1=5) -%}
-{%- call thrice(4) -%}
+{%- call thrice() -%}{%- endcall -%}
+{%- call thrice(param1=4) -%}{%- endcall -%}
+{%- call thrice(param2=4) -%}{%- endcall -%}
+{%- call thrice(param2=4, param1=5) -%}{%- endcall -%}
+{%- call thrice(4) -%}{%- endcall -%}
 ",
         ext = "html"
     )]
@@ -205,7 +205,7 @@ fn test_default_value2() {
 {{ param1 }} {{ param2 }} {{ param3 }}
 {% endmacro -%}
 
-{%- call thrice(4, param3=5) -%}
+{%- call thrice(4, param3=5) -%}{%- endcall -%}
 ",
         ext = "html"
     )]
@@ -223,10 +223,10 @@ fn test_default_value3() {
 {{ a }} {{ b }} {{ c }}
 {% endmacro -%}
 
-{%- call thrice() -%}
-{%- call thrice(b=6) -%}
-{%- call thrice(c=3) -%}
-{%- call thrice(a=3) -%}
+{%- call thrice() -%}{%- endcall -%}
+{%- call thrice(b=6) -%}{%- endcall -%}
+{%- call thrice(c=3) -%}{%- endcall -%}
+{%- call thrice(a=3) -%}{%- endcall -%}
 ",
         ext = "html"
     )]
@@ -250,9 +250,9 @@ fn test_default_value4() {
 {% endmacro -%}
 
 {%- let y = 4 -%}
-{%- call thrice() -%}
-{%- call thrice(1) -%}
-{%- call thrice(b=1) -%}
+{%- call thrice() -%}{%- endcall -%}
+{%- call thrice(1) -%}{%- endcall -%}
+{%- call thrice(b=1) -%}{%- endcall -%}
 ",
         ext = "html"
     )]
@@ -272,9 +272,9 @@ fn test_default_value5() {
 {{ a }} {{ b }}
 {% endmacro -%}
 
-{%- call thrice() -%}
-{%- call thrice(1) -%}
-{%- call thrice(1, 2) -%}
+{%- call thrice() -%}{%- endcall -%}
+{%- call thrice(1) -%}{%- endcall -%}
+{%- call thrice(1, 2) -%}{%- endcall -%}
 ",
         ext = "html"
     )]
@@ -296,8 +296,8 @@ fn test_rust_keywords_as_args() {
 {{ type }}
 {% endmacro -%}
 
-{%- call input(1) -%}
-{%- call input(type=1) -%}
+{%- call input(1) -%}{%- endcall -%}
+{%- call input(type=1) -%}{%- endcall -%}
 ",
         ext = "html"
     )]
@@ -321,9 +321,9 @@ fn test_rust_keywords_as_args_with_default() {
 {{ type }}
 {% endmacro -%}
 
-{%- call input() -%}
-{%- call input(1) -%}
-{%- call input(type=1) -%}
+{%- call input() -%}{%- endcall -%}
+{%- call input(1) -%}{%- endcall -%}
+{%- call input(type=1) -%}{%- endcall -%}
 ",
         ext = "html"
     )]
@@ -347,9 +347,9 @@ fn test_rust_keywords_as_args_with_default_expr() {
 {{ type }}
 {% endmacro -%}
 
-{%- call input() -%}
-{%- call input(1) -%}
-{%- call input(type=1) -%}
+{%- call input() -%}{%- endcall -%}
+{%- call input(1) -%}{%- endcall -%}
+{%- call input(type=1) -%}{%- endcall -%}
 ",
         ext = "html"
     )]

--- a/testing/tests/ui/caller_arguments.rs
+++ b/testing/tests/ui/caller_arguments.rs
@@ -1,0 +1,70 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(
+    source = r#"
+    {% macro test() %}
+        {{- caller("a", "b") -}}
+    {%- endmacro -%}
+    {%- call(a,b,c) test() -%}
+        {{- a -}}
+    {%- endcall -%}
+    "#,
+    ext = "txt"
+)]
+struct InvalidNumberArguments {
+}
+
+#[derive(Template)]
+#[template(
+    source = r#"
+    {% macro test() %}
+        {{- caller("a") -}}
+    {%- endmacro -%}
+    {%- call(a test() -%}
+        {{- a -}}
+    {%- endcall -%}
+    "#,
+    ext = "txt"
+)]
+struct NoClosingParen {
+}
+
+#[derive(Template)]
+#[template(
+    source = r#"
+    {% macro test() %}
+        {{- caller("a") -}}
+    {%- endmacro -%}
+    {%- call(a) test() -%}
+        {{- caller(a) -}}
+    {%- endcall -%}
+    "#,
+    ext = "txt"
+)]
+struct CallerInCaller {
+}
+
+#[derive(Template)]
+#[template(
+    source = r#"
+    {% macro test2() %}
+        {{ caller("bb") }}
+    {% endmacro %}
+    {% macro test() %}
+        {{ caller("a") }}
+    {%- endmacro -%}
+    {%- call(a) test() -%}
+        {% call(b) test2() %}
+            {{ caller("b") }}
+        {% endcall %}
+        {{- a -}}
+    {%- endcall -%}
+    "#,
+    ext = "txt"
+)]
+struct CallerInCaller1 {
+}
+
+fn main() {}
+

--- a/testing/tests/ui/caller_arguments.rs
+++ b/testing/tests/ui/caller_arguments.rs
@@ -19,6 +19,21 @@ struct InvalidNumberArguments {
 #[template(
     source = r#"
     {% macro test() %}
+        {{- caller("a", "b") -}}
+    {%- endmacro -%}
+    {%- call(a) test() -%}
+        {{- a -}}
+    {%- endcall -%}
+    "#,
+    ext = "txt"
+)]
+struct InvalidNumberArguments1 {
+}
+
+#[derive(Template)]
+#[template(
+    source = r#"
+    {% macro test() %}
         {{- caller("a") -}}
     {%- endmacro -%}
     {%- call(a test() -%}
@@ -64,6 +79,29 @@ struct CallerInCaller {
     ext = "txt"
 )]
 struct CallerInCaller1 {
+}
+
+#[derive(Template)]
+#[template(
+    source = r#"{{caller()}}"#,
+    ext = "txt"
+)]
+struct JustCaller{
+}
+
+#[derive(Template)]
+#[template(
+    source = r#"
+    {% macro test() %}
+        {{ caller("a", one = "b") }}
+    {%- endmacro -%}
+    {%- call(two, one) test() -%}
+        {{- two -}} {{- one -}}
+    {%- endcall -%}
+    "#,
+    ext = "txt"
+)]
+struct NamedArguments {
 }
 
 fn main() {}

--- a/testing/tests/ui/caller_arguments.stderr
+++ b/testing/tests/ui/caller_arguments.stderr
@@ -1,0 +1,59 @@
+error: missing `c` argument
+ --> InvalidNumberArguments.txt:3:18
+       "(\"a\", \"b\") -}}\n    {%- endmacro -%}\n    {%- call(a,b,c) test() -%}\n        {{- a"...
+  --> tests/ui/caller_arguments.rs:5:14
+   |
+5  |       source = r#"
+   |  ______________^
+6  | |     {% macro test() %}
+7  | |         {{- caller("a", "b") -}}
+8  | |     {%- endmacro -%}
+...  |
+11 | |     {%- endcall -%}
+12 | |     "#,
+   | |______^
+
+error: expected `)` to close call argument list
+ --> <source attribute>:5:15
+       "test() -%}\n        {{- a -}}\n    {%- endcall -%}\n    "
+  --> tests/ui/caller_arguments.rs:20:14
+   |
+20 |       source = r#"
+   |  ______________^
+21 | |     {% macro test() %}
+22 | |         {{- caller("a") -}}
+23 | |     {%- endmacro -%}
+...  |
+26 | |     {%- endcall -%}
+27 | |     "#,
+   | |______^
+
+error: block is not defined for caller
+ --> CallerInCaller.txt:6:18
+       "(a) -}}\n    {%- endcall -%}\n    "
+  --> tests/ui/caller_arguments.rs:35:14
+   |
+35 |       source = r#"
+   |  ______________^
+36 | |     {% macro test() %}
+37 | |         {{- caller("a") -}}
+38 | |     {%- endmacro -%}
+...  |
+41 | |     {%- endcall -%}
+42 | |     "#,
+   | |______^
+
+error: block is not defined for caller
+ --> CallerInCaller1.txt:10:21
+       "(\"b\") }}\n        {% endcall %}\n        {{- a -}}\n    {%- endcall -%}\n    "
+  --> tests/ui/caller_arguments.rs:50:14
+   |
+50 |       source = r#"
+   |  ______________^
+51 | |     {% macro test2() %}
+52 | |         {{ caller("bb") }}
+53 | |     {% endmacro %}
+...  |
+62 | |     {%- endcall -%}
+63 | |     "#,
+   | |______^

--- a/testing/tests/ui/caller_arguments.stderr
+++ b/testing/tests/ui/caller_arguments.stderr
@@ -1,4 +1,4 @@
-error: expected `3` argument, found `2`
+error: expected 3 arguments in `caller`, found 2
  --> InvalidNumberArguments.txt:3:18
        "(\"a\", \"b\") -}}\n    {%- endmacro -%}\n    {%- call(a,b,c) test() -%}\n        {{- a"...
   --> tests/ui/caller_arguments.rs:5:14
@@ -13,85 +13,85 @@ error: expected `3` argument, found `2`
 12 | |     "#,
    | |______^
 
-error: expected `1` argument, found `2`
+error: expected 1 argument in `caller`, found 2
  --> InvalidNumberArguments1.txt:3:18
        "(\"a\", \"b\") -}}\n    {%- endmacro -%}\n    {%- call(a) test() -%}\n        {{- a -}}"...
-  --> tests/ui/caller_arguments.rs:21:14
+  --> tests/ui/caller_arguments.rs:20:14
    |
-21 |       source = r#"
+20 |       source = r#"
    |  ______________^
-22 | |     {% macro test() %}
-23 | |         {{- caller("a", "b") -}}
-24 | |     {%- endmacro -%}
+21 | |     {% macro test() %}
+22 | |         {{- caller("a", "b") -}}
+23 | |     {%- endmacro -%}
 ...  |
-27 | |     {%- endcall -%}
-28 | |     "#,
+26 | |     {%- endcall -%}
+27 | |     "#,
    | |______^
 
 error: expected `)` to close call argument list
  --> <source attribute>:5:15
        "test() -%}\n        {{- a -}}\n    {%- endcall -%}\n    "
-  --> tests/ui/caller_arguments.rs:36:14
+  --> tests/ui/caller_arguments.rs:35:14
    |
-36 |       source = r#"
+35 |       source = r#"
    |  ______________^
-37 | |     {% macro test() %}
-38 | |         {{- caller("a") -}}
-39 | |     {%- endmacro -%}
+36 | |     {% macro test() %}
+37 | |         {{- caller("a") -}}
+38 | |     {%- endmacro -%}
 ...  |
-42 | |     {%- endcall -%}
-43 | |     "#,
+41 | |     {%- endcall -%}
+42 | |     "#,
    | |______^
 
-error: block is not defined for caller
+error: block is not defined for `caller`
  --> CallerInCaller.txt:6:18
        "(a) -}}\n    {%- endcall -%}\n    "
-  --> tests/ui/caller_arguments.rs:51:14
+  --> tests/ui/caller_arguments.rs:50:14
    |
-51 |       source = r#"
+50 |       source = r#"
    |  ______________^
-52 | |     {% macro test() %}
-53 | |         {{- caller("a") -}}
-54 | |     {%- endmacro -%}
+51 | |     {% macro test() %}
+52 | |         {{- caller("a") -}}
+53 | |     {%- endmacro -%}
 ...  |
-57 | |     {%- endcall -%}
-58 | |     "#,
+56 | |     {%- endcall -%}
+57 | |     "#,
    | |______^
 
-error: block is not defined for caller
+error: block is not defined for `caller`
  --> CallerInCaller1.txt:10:21
        "(\"b\") }}\n        {% endcall %}\n        {{- a -}}\n    {%- endcall -%}\n    "
-  --> tests/ui/caller_arguments.rs:66:14
+  --> tests/ui/caller_arguments.rs:65:14
    |
-66 |       source = r#"
+65 |       source = r#"
    |  ______________^
-67 | |     {% macro test2() %}
-68 | |         {{ caller("bb") }}
-69 | |     {% endmacro %}
+66 | |     {% macro test2() %}
+67 | |         {{ caller("bb") }}
+68 | |     {% endmacro %}
 ...  |
-78 | |     {%- endcall -%}
-79 | |     "#,
+77 | |     {%- endcall -%}
+78 | |     "#,
    | |______^
 
-error: block is not defined for caller
+error: block is not defined for `caller`
  --> JustCaller.txt:1:8
        "()}}"
-  --> tests/ui/caller_arguments.rs:87:14
+  --> tests/ui/caller_arguments.rs:86:14
    |
-87 |     source = r#"{{caller()}}"#,
+86 |     source = r#"{{caller()}}"#,
    |              ^^^^^^^^^^^^^^^^^
 
 error: failed to parse template source
  --> <source attribute>:3:27
        "= \"b\") }}\n    {%- endmacro -%}\n    {%- call(two, one) test() -%}\n        {{- two"...
-   --> tests/ui/caller_arguments.rs:95:14
+   --> tests/ui/caller_arguments.rs:94:14
     |
-95  |       source = r#"
+94  |       source = r#"
     |  ______________^
-96  | |     {% macro test() %}
-97  | |         {{ caller("a", one = "b") }}
-98  | |     {%- endmacro -%}
+95  | |     {% macro test() %}
+96  | |         {{ caller("a", one = "b") }}
+97  | |     {%- endmacro -%}
 ...   |
-101 | |     {%- endcall -%}
-102 | |     "#,
+100 | |     {%- endcall -%}
+101 | |     "#,
     | |______^

--- a/testing/tests/ui/caller_arguments.stderr
+++ b/testing/tests/ui/caller_arguments.stderr
@@ -1,4 +1,4 @@
-error: missing `c` argument
+error: expected `3` argument, found `2`
  --> InvalidNumberArguments.txt:3:18
        "(\"a\", \"b\") -}}\n    {%- endmacro -%}\n    {%- call(a,b,c) test() -%}\n        {{- a"...
   --> tests/ui/caller_arguments.rs:5:14
@@ -13,47 +13,85 @@ error: missing `c` argument
 12 | |     "#,
    | |______^
 
+error: expected `1` argument, found `2`
+ --> InvalidNumberArguments1.txt:3:18
+       "(\"a\", \"b\") -}}\n    {%- endmacro -%}\n    {%- call(a) test() -%}\n        {{- a -}}"...
+  --> tests/ui/caller_arguments.rs:21:14
+   |
+21 |       source = r#"
+   |  ______________^
+22 | |     {% macro test() %}
+23 | |         {{- caller("a", "b") -}}
+24 | |     {%- endmacro -%}
+...  |
+27 | |     {%- endcall -%}
+28 | |     "#,
+   | |______^
+
 error: expected `)` to close call argument list
  --> <source attribute>:5:15
        "test() -%}\n        {{- a -}}\n    {%- endcall -%}\n    "
-  --> tests/ui/caller_arguments.rs:20:14
+  --> tests/ui/caller_arguments.rs:36:14
    |
-20 |       source = r#"
+36 |       source = r#"
    |  ______________^
-21 | |     {% macro test() %}
-22 | |         {{- caller("a") -}}
-23 | |     {%- endmacro -%}
+37 | |     {% macro test() %}
+38 | |         {{- caller("a") -}}
+39 | |     {%- endmacro -%}
 ...  |
-26 | |     {%- endcall -%}
-27 | |     "#,
+42 | |     {%- endcall -%}
+43 | |     "#,
    | |______^
 
 error: block is not defined for caller
  --> CallerInCaller.txt:6:18
        "(a) -}}\n    {%- endcall -%}\n    "
-  --> tests/ui/caller_arguments.rs:35:14
+  --> tests/ui/caller_arguments.rs:51:14
    |
-35 |       source = r#"
+51 |       source = r#"
    |  ______________^
-36 | |     {% macro test() %}
-37 | |         {{- caller("a") -}}
-38 | |     {%- endmacro -%}
+52 | |     {% macro test() %}
+53 | |         {{- caller("a") -}}
+54 | |     {%- endmacro -%}
 ...  |
-41 | |     {%- endcall -%}
-42 | |     "#,
+57 | |     {%- endcall -%}
+58 | |     "#,
    | |______^
 
 error: block is not defined for caller
  --> CallerInCaller1.txt:10:21
        "(\"b\") }}\n        {% endcall %}\n        {{- a -}}\n    {%- endcall -%}\n    "
-  --> tests/ui/caller_arguments.rs:50:14
+  --> tests/ui/caller_arguments.rs:66:14
    |
-50 |       source = r#"
+66 |       source = r#"
    |  ______________^
-51 | |     {% macro test2() %}
-52 | |         {{ caller("bb") }}
-53 | |     {% endmacro %}
+67 | |     {% macro test2() %}
+68 | |         {{ caller("bb") }}
+69 | |     {% endmacro %}
 ...  |
-62 | |     {%- endcall -%}
-63 | |     "#,
+78 | |     {%- endcall -%}
+79 | |     "#,
    | |______^
+
+error: block is not defined for caller
+ --> JustCaller.txt:1:8
+       "()}}"
+  --> tests/ui/caller_arguments.rs:87:14
+   |
+87 |     source = r#"{{caller()}}"#,
+   |              ^^^^^^^^^^^^^^^^^
+
+error: failed to parse template source
+ --> <source attribute>:3:27
+       "= \"b\") }}\n    {%- endmacro -%}\n    {%- call(two, one) test() -%}\n        {{- two"...
+   --> tests/ui/caller_arguments.rs:95:14
+    |
+95  |       source = r#"
+    |  ______________^
+96  | |     {% macro test() %}
+97  | |         {{ caller("a", one = "b") }}
+98  | |     {%- endmacro -%}
+...   |
+101 | |     {%- endcall -%}
+102 | |     "#,
+    | |______^

--- a/testing/tests/ui/macro-caller.rs
+++ b/testing/tests/ui/macro-caller.rs
@@ -1,0 +1,8 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(source = "{%- macro caller() -%}{%- endmacro -%}", ext = "html")]
+struct MacroSuper;
+
+fn main() {
+}

--- a/testing/tests/ui/macro-caller.stderr
+++ b/testing/tests/ui/macro-caller.stderr
@@ -1,0 +1,7 @@
+error: 'caller' is not a valid name for a macro
+ --> <source attribute>:1:2
+       "- macro caller() -%}{%- endmacro -%}"
+ --> tests/ui/macro-caller.rs:4:21
+  |
+4 | #[template(source = "{%- macro caller() -%}{%- endmacro -%}", ext = "html")]
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testing/tests/ui/macro-recursion.rs
+++ b/testing/tests/ui/macro-recursion.rs
@@ -3,8 +3,8 @@ use askama::Template;
 #[derive(Template)]
 #[template(
     source = "
-        {% macro one %}{% call one %}{% endmacro %}
-        {% call one %}
+        {% macro one %}{% call one %}{% endcall %}{% endmacro %}
+        {% call one %}{% endcall %}
     ",
     ext = "html"
 )]
@@ -13,12 +13,12 @@ struct Direct;
 #[derive(Template)]
 #[template(
     source = "
-        {% macro one %}{% call two %}{% endmacro %}
-        {% macro two %}{% call three %}{% endmacro %}
-        {% macro three %}{% call four %}{% endmacro %}
-        {% macro four %}{% call five %}{% endmacro %}
-        {% macro five %}{% call one %}{% endmacro %}
-        {% call one %}
+        {% macro one %}{% call two %}{% endcall %}{% endmacro %}
+        {% macro two %}{% call three %}{% endcall %}{% endmacro %}
+        {% macro three %}{% call four %}{% endcall %}{% endmacro %}
+        {% macro four %}{% call five %}{% endcall %}{% endmacro %}
+        {% macro five %}{% call one %}{% endcall %}{% endmacro %}
+        {% call one %}{% endcall %}
     ",
     ext = "html"
 )]
@@ -29,9 +29,9 @@ struct Indirect;
     source = r#"
         {% import "macro-recursion-1.html" as next %}
         {% macro some_macro %}
-            {% call next::some_macro %}
+            {% call next::some_macro %}{% endcall %}
         {% endmacro %}
-        {% call some_macro %}
+        {% call some_macro %}{% endcall %}
     "#,
     ext = "html"
 )]

--- a/testing/tests/ui/macro-recursion.stderr
+++ b/testing/tests/ui/macro-recursion.stderr
@@ -1,61 +1,61 @@
 error: Found recursion in macro calls:
  --> Direct.html:3:10
-       " call one %}\n    "
+       " call one %}{% endcall %}\n    "
          --> Direct.html:2:25
-       " call one %}{% endmacro %}\n        {% call one %}\n    "
+       " call one %}{% endcall %}{% endmacro %}\n        {% call one %}{% endcall %}\n    "
  --> tests/ui/macro-recursion.rs:5:14
   |
 5 |       source = "
   |  ______________^
-6 | |         {% macro one %}{% call one %}{% endmacro %}
-7 | |         {% call one %}
+6 | |         {% macro one %}{% call one %}{% endcall %}{% endmacro %}
+7 | |         {% call one %}{% endcall %}
 8 | |     ",
   | |_____^
 
 error: Found recursion in macro calls:
  --> Indirect.html:7:10
-       " call one %}\n    "
+       " call one %}{% endcall %}\n    "
          --> Indirect.html:2:25
-       " call two %}{% endmacro %}\n        {% macro two %}{% call three %}{% endmacro %}"...
+       " call two %}{% endcall %}{% endmacro %}\n        {% macro two %}{% call three %}{"...
          --> Indirect.html:3:25
-       " call three %}{% endmacro %}\n        {% macro three %}{% call four %}{% endmacro"...
+       " call three %}{% endcall %}{% endmacro %}\n        {% macro three %}{% call four "...
          --> Indirect.html:4:27
-       " call four %}{% endmacro %}\n        {% macro four %}{% call five %}{% endmacro %"...
+       " call four %}{% endcall %}{% endmacro %}\n        {% macro four %}{% call five %}"...
          --> Indirect.html:5:26
-       " call five %}{% endmacro %}\n        {% macro five %}{% call one %}{% endmacro %}"...
+       " call five %}{% endcall %}{% endmacro %}\n        {% macro five %}{% call one %}{"...
          --> Indirect.html:6:26
-       " call one %}{% endmacro %}\n        {% call one %}\n    "
+       " call one %}{% endcall %}{% endmacro %}\n        {% call one %}{% endcall %}\n    "
   --> tests/ui/macro-recursion.rs:15:14
    |
 15 |       source = "
    |  ______________^
-16 | |         {% macro one %}{% call two %}{% endmacro %}
-17 | |         {% macro two %}{% call three %}{% endmacro %}
-18 | |         {% macro three %}{% call four %}{% endmacro %}
+16 | |         {% macro one %}{% call two %}{% endcall %}{% endmacro %}
+17 | |         {% macro two %}{% call three %}{% endcall %}{% endmacro %}
+18 | |         {% macro three %}{% call four %}{% endcall %}{% endmacro %}
 ...  |
-21 | |         {% call one %}
+21 | |         {% call one %}{% endcall %}
 22 | |     ",
    | |_____^
 
 error: Found recursion in macro calls:
  --> AcrossImports.html:6:10
-       " call some_macro %}\n    "
+       " call some_macro %}{% endcall %}\n    "
          --> AcrossImports.html:4:14
-       " call next::some_macro %}\n        {% endmacro %}\n        {% call some_macro %}\n "...
+       " call next::some_macro %}{% endcall %}\n        {% endmacro %}\n        {% call so"...
          --> testing/templates/macro-recursion-1.html:4:6
-       " call next::some_macro %}\n{% endmacro %}"
+       " call next::some_macro %}{% endcall %}\n{% endmacro %}"
          --> testing/templates/macro-recursion-2.html:4:6
-       " call next::some_macro %}\n{% endmacro %}"
+       " call next::some_macro %}{% endcall %}\n{% endmacro %}"
          --> testing/templates/macro-recursion-3.html:4:6
-       " call next::some_macro %}\n{% endmacro %}"
+       " call next::some_macro %}{% endcall %}\n{% endmacro %}"
   --> tests/ui/macro-recursion.rs:29:14
    |
 29 |       source = r#"
    |  ______________^
 30 | |         {% import "macro-recursion-1.html" as next %}
 31 | |         {% macro some_macro %}
-32 | |             {% call next::some_macro %}
+32 | |             {% call next::some_macro %}{% endcall %}
 33 | |         {% endmacro %}
-34 | |         {% call some_macro %}
+34 | |         {% call some_macro %}{% endcall %}
 35 | |     "#,
    | |______^

--- a/testing/tests/ui/macro.rs
+++ b/testing/tests/ui/macro.rs
@@ -5,7 +5,7 @@ use askama::Template;
 {{ param }}
 {%- endmacro -%}
 
-{%- call thrice(2, 3) -%}", ext = "html")]
+{%- call thrice(2, 3) -%}{%- endcall -%}", ext = "html")]
 struct InvalidNumberOfArgs;
 
 #[derive(Template)]
@@ -13,14 +13,14 @@ struct InvalidNumberOfArgs;
 {{ param }} {{ param2 }}
 {%- endmacro -%}
 
-{%- call thrice() -%}", ext = "html")]
+{%- call thrice() -%}{%- endcall -%}", ext = "html")]
 struct InvalidNumberOfArgs2;
 
 #[derive(Template)]
 #[template(source = "{%- macro thrice() -%}
 {%- endmacro -%}
 
-{%- call thrice(1, 2) -%}", ext = "html")]
+{%- call thrice(1, 2) -%}{%- endcall -%}", ext = "html")]
 struct InvalidNumberOfArgs3;
 
 #[derive(Template)]
@@ -44,7 +44,7 @@ struct NoClosingParen4;
     source = r#"
         {% macro example(name, value, current, label="", id="") %}
         {% endmacro %}
-        {% call example(name="name", value="") %}
+        {% call example(name="name", value="") %}{% endcall %}
     "#,
     ext = "txt"
 )]
@@ -55,7 +55,7 @@ struct WrongNumberOfParams;
     source = r#"
         {% macro example(name, value, arg=12) %}
         {% endmacro %}
-        {% call example(0, name="name", value="") %}
+        {% call example(0, name="name", value="") %}{% endcall %}
     "#,
     ext = "txt"
 )]

--- a/testing/tests/ui/macro.stderr
+++ b/testing/tests/ui/macro.stderr
@@ -1,6 +1,6 @@
 error: macro `thrice` expected 1 argument, found 2
  --> InvalidNumberOfArgs.html:5:2
-       "- call thrice(2, 3) -%}"
+       "- call thrice(2, 3) -%}{%- endcall -%}"
  --> tests/ui/macro.rs:4:21
   |
 4 |   #[template(source = "{%- macro thrice(param) -%}
@@ -8,12 +8,12 @@ error: macro `thrice` expected 1 argument, found 2
 5 | | {{ param }}
 6 | | {%- endmacro -%}
 7 | |
-8 | | {%- call thrice(2, 3) -%}", ext = "html")]
-  | |__________________________^
+8 | | {%- call thrice(2, 3) -%}{%- endcall -%}", ext = "html")]
+  | |_________________________________________^
 
 error: missing arguments when calling macro `thrice`: `param` and `param2`
  --> InvalidNumberOfArgs2.html:5:2
-       "- call thrice() -%}"
+       "- call thrice() -%}{%- endcall -%}"
   --> tests/ui/macro.rs:12:21
    |
 12 |   #[template(source = "{%- macro thrice(param, param2) -%}
@@ -21,20 +21,20 @@ error: missing arguments when calling macro `thrice`: `param` and `param2`
 13 | | {{ param }} {{ param2 }}
 14 | | {%- endmacro -%}
 15 | |
-16 | | {%- call thrice() -%}", ext = "html")]
-   | |______________________^
+16 | | {%- call thrice() -%}{%- endcall -%}", ext = "html")]
+   | |_____________________________________^
 
 error: macro `thrice` expected 0 argument, found 2
  --> InvalidNumberOfArgs3.html:4:2
-       "- call thrice(1, 2) -%}"
+       "- call thrice(1, 2) -%}{%- endcall -%}"
   --> tests/ui/macro.rs:20:21
    |
 20 |   #[template(source = "{%- macro thrice() -%}
    |  _____________________^
 21 | | {%- endmacro -%}
 22 | |
-23 | | {%- call thrice(1, 2) -%}", ext = "html")]
-   | |__________________________^
+23 | | {%- call thrice(1, 2) -%}{%- endcall -%}", ext = "html")]
+   | |_________________________________________^
 
 error: expected `)` to close macro argument list
  --> <source attribute>:1:17
@@ -70,26 +70,26 @@ error: expected `)` to close macro argument list
 
 error: missing argument when calling macro `example`: `current`
  --> WrongNumberOfParams.txt:4:10
-       " call example(name=\"name\", value=\"\") %}\n    "
+       " call example(name=\"name\", value=\"\") %}{% endcall %}\n    "
   --> tests/ui/macro.rs:44:14
    |
 44 |       source = r#"
    |  ______________^
 45 | |         {% macro example(name, value, current, label="", id="") %}
 46 | |         {% endmacro %}
-47 | |         {% call example(name="name", value="") %}
+47 | |         {% call example(name="name", value="") %}{% endcall %}
 48 | |     "#,
    | |______^
 
 error: argument `name` was passed more than once when calling macro `example`
  --> DuplicatedArg.txt:4:10
-       " call example(0, name=\"name\", value=\"\") %}\n    "
+       " call example(0, name=\"name\", value=\"\") %}{% endcall %}\n    "
   --> tests/ui/macro.rs:55:14
    |
 55 |       source = r#"
    |  ______________^
 56 | |         {% macro example(name, value, arg=12) %}
 57 | |         {% endmacro %}
-58 | |         {% call example(0, name="name", value="") %}
+58 | |         {% call example(0, name="name", value="") %}{% endcall %}
 59 | |     "#,
    | |______^

--- a/testing/tests/ui/macro_default_value.rs
+++ b/testing/tests/ui/macro_default_value.rs
@@ -4,14 +4,14 @@ use askama::Template;
 #[template(source = "{%- macro thrice(param1, param2=0) -%}
 {{ param1 }} {{ param2 }}
 {%- endmacro -%}
-{%- call thrice() -%}", ext = "html")]
+{%- call thrice() -%}{%- endcall -%}", ext = "html")]
 struct InvalidDefault1;
 
 #[derive(Template)]
 #[template(source = "{%- macro thrice(param1, param2=0) -%}
 {{ param1 }} {{ param2 }}
 {%- endmacro -%}
-{%- call thrice(1, 2, 3) -%}", ext = "html")]
+{%- call thrice(1, 2, 3) -%}{%- endcall -%}", ext = "html")]
 struct InvalidDefault2;
 
 fn main() {

--- a/testing/tests/ui/macro_default_value.stderr
+++ b/testing/tests/ui/macro_default_value.stderr
@@ -1,23 +1,23 @@
 error: missing argument when calling macro `thrice`: `param1`
  --> InvalidDefault1.html:4:2
-       "- call thrice() -%}"
+       "- call thrice() -%}{%- endcall -%}"
  --> tests/ui/macro_default_value.rs:4:21
   |
 4 |   #[template(source = "{%- macro thrice(param1, param2=0) -%}
   |  _____________________^
 5 | | {{ param1 }} {{ param2 }}
 6 | | {%- endmacro -%}
-7 | | {%- call thrice() -%}", ext = "html")]
-  | |______________________^
+7 | | {%- call thrice() -%}{%- endcall -%}", ext = "html")]
+  | |_____________________________________^
 
 error: macro `thrice` expected 2 arguments, found 3
  --> InvalidDefault2.html:4:2
-       "- call thrice(1, 2, 3) -%}"
+       "- call thrice(1, 2, 3) -%}{%- endcall -%}"
   --> tests/ui/macro_default_value.rs:11:21
    |
 11 |   #[template(source = "{%- macro thrice(param1, param2=0) -%}
    |  _____________________^
 12 | | {{ param1 }} {{ param2 }}
 13 | | {%- endmacro -%}
-14 | | {%- call thrice(1, 2, 3) -%}", ext = "html")]
-   | |_____________________________^
+14 | | {%- call thrice(1, 2, 3) -%}{%- endcall -%}", ext = "html")]
+   | |____________________________________________^

--- a/testing/tests/ui/macro_named_argument.rs
+++ b/testing/tests/ui/macro_named_argument.rs
@@ -5,7 +5,7 @@ use askama::Template;
 {{ param1 }} {{ param2 }}
 {%- endmacro -%}
 
-{%- call thrice(param1=2, param3=3) -%}", ext = "html")]
+{%- call thrice(param1=2, param3=3) -%}{%- endcall -%}", ext = "html")]
 struct InvalidNamedArg;
 
 #[derive(Template)]
@@ -13,7 +13,7 @@ struct InvalidNamedArg;
 {{ param1 }} {{ param2 }}
 {%- endmacro -%}
 
-{%- call thrice(param1=2, param1=3) -%}", ext = "html")]
+{%- call thrice(param1=2, param1=3) -%}{%- endcall -%}", ext = "html")]
 struct InvalidNamedArg2;
 
 // Ensures that filters can't have named arguments.
@@ -22,7 +22,7 @@ struct InvalidNamedArg2;
 {{ param1 }} {{ param2 }}
 {%- endmacro -%}
 
-{%- call thrice(3, param1=2)|filter(param1=12) -%}", ext = "html")]
+{%- call thrice(3, param1=2)|filter(param1=12) -%}{%- endcall -%}", ext = "html")]
 struct InvalidNamedArg3;
 
 // Ensures that named arguments can only be passed last.
@@ -30,7 +30,7 @@ struct InvalidNamedArg3;
 #[template(source = "{%- macro thrice(param1, param2) -%}
 {{ param1 }} {{ param2 }}
 {%- endmacro -%}
-{%- call thrice(param1=2, 3) -%}", ext = "html")]
+{%- call thrice(param1=2, 3) -%}{%- endcall -%}", ext = "html")]
 struct InvalidNamedArg4;
 
 // Ensures that named arguments can't be used for arguments before them.
@@ -38,19 +38,19 @@ struct InvalidNamedArg4;
 #[template(source = "{%- macro thrice(param1, param2) -%}
 {{ param1 }} {{ param2 }}
 {%- endmacro -%}
-{%- call thrice(3, param1=2) -%}", ext = "html")]
+{%- call thrice(3, param1=2) -%}{%- endcall -%}", ext = "html")]
 struct InvalidNamedArg5;
 
 #[derive(Template)]
 #[template(source = "{%- macro thrice(param1, param2) -%}
 {%- endmacro -%}
-{%- call thrice() -%}", ext = "html")]
+{%- call thrice() -%}{%- endcall -%}", ext = "html")]
 struct MissingArgs;
 
 #[derive(Template)]
 #[template(source = "{%- macro thrice(param1, param2=1) -%}
 {%- endmacro -%}
-{%- call thrice() -%}", ext = "html")]
+{%- call thrice() -%}{%- endcall -%}", ext = "html")]
 struct MissingArgs2;
 
 fn main() {

--- a/testing/tests/ui/macro_named_argument.stderr
+++ b/testing/tests/ui/macro_named_argument.stderr
@@ -1,6 +1,6 @@
 error: missing argument when calling macro `thrice`: `param2`
  --> InvalidNamedArg.html:5:2
-       "- call thrice(param1=2, param3=3) -%}"
+       "- call thrice(param1=2, param3=3) -%}{%- endcall -%}"
  --> tests/ui/macro_named_argument.rs:4:21
   |
 4 |   #[template(source = "{%- macro thrice(param1, param2) -%}
@@ -8,12 +8,12 @@ error: missing argument when calling macro `thrice`: `param2`
 5 | | {{ param1 }} {{ param2 }}
 6 | | {%- endmacro -%}
 7 | |
-8 | | {%- call thrice(param1=2, param3=3) -%}", ext = "html")]
-  | |________________________________________^
+8 | | {%- call thrice(param1=2, param3=3) -%}{%- endcall -%}", ext = "html")]
+  | |_______________________________________________________^
 
 error: named argument `param1` was passed more than once
  --> <source attribute>:5:15
-       "(param1=2, param1=3) -%}"
+       "(param1=2, param1=3) -%}{%- endcall -%}"
   --> tests/ui/macro_named_argument.rs:12:21
    |
 12 |   #[template(source = "{%- macro thrice(param1, param2) -%}
@@ -21,12 +21,12 @@ error: named argument `param1` was passed more than once
 13 | | {{ param1 }} {{ param2 }}
 14 | | {%- endmacro -%}
 15 | |
-16 | | {%- call thrice(param1=2, param1=3) -%}", ext = "html")]
-   | |________________________________________^
+16 | | {%- call thrice(param1=2, param1=3) -%}{%- endcall -%}", ext = "html")]
+   | |_______________________________________________________^
 
 error: failed to parse template source
  --> <source attribute>:5:28
-       "|filter(param1=12) -%}"
+       "|filter(param1=12) -%}{%- endcall -%}"
   --> tests/ui/macro_named_argument.rs:21:21
    |
 21 |   #[template(source = "{%- macro thrice(param1, param2) -%}
@@ -34,51 +34,51 @@ error: failed to parse template source
 22 | | {{ param1 }} {{ param2 }}
 23 | | {%- endmacro -%}
 24 | |
-25 | | {%- call thrice(3, param1=2)|filter(param1=12) -%}", ext = "html")]
-   | |___________________________________________________^
+25 | | {%- call thrice(3, param1=2)|filter(param1=12) -%}{%- endcall -%}", ext = "html")]
+   | |__________________________________________________________________^
 
 error: named arguments must always be passed last
  --> <source attribute>:4:15
-       "(param1=2, 3) -%}"
+       "(param1=2, 3) -%}{%- endcall -%}"
   --> tests/ui/macro_named_argument.rs:30:21
    |
 30 |   #[template(source = "{%- macro thrice(param1, param2) -%}
    |  _____________________^
 31 | | {{ param1 }} {{ param2 }}
 32 | | {%- endmacro -%}
-33 | | {%- call thrice(param1=2, 3) -%}", ext = "html")]
-   | |_________________________________^
+33 | | {%- call thrice(param1=2, 3) -%}{%- endcall -%}", ext = "html")]
+   | |________________________________________________^
 
 error: argument `param1` was passed more than once when calling macro `thrice`
  --> InvalidNamedArg5.html:4:2
-       "- call thrice(3, param1=2) -%}"
+       "- call thrice(3, param1=2) -%}{%- endcall -%}"
   --> tests/ui/macro_named_argument.rs:38:21
    |
 38 |   #[template(source = "{%- macro thrice(param1, param2) -%}
    |  _____________________^
 39 | | {{ param1 }} {{ param2 }}
 40 | | {%- endmacro -%}
-41 | | {%- call thrice(3, param1=2) -%}", ext = "html")]
-   | |_________________________________^
+41 | | {%- call thrice(3, param1=2) -%}{%- endcall -%}", ext = "html")]
+   | |________________________________________________^
 
 error: missing arguments when calling macro `thrice`: `param1` and `param2`
  --> MissingArgs.html:3:2
-       "- call thrice() -%}"
+       "- call thrice() -%}{%- endcall -%}"
   --> tests/ui/macro_named_argument.rs:45:21
    |
 45 |   #[template(source = "{%- macro thrice(param1, param2) -%}
    |  _____________________^
 46 | | {%- endmacro -%}
-47 | | {%- call thrice() -%}", ext = "html")]
-   | |______________________^
+47 | | {%- call thrice() -%}{%- endcall -%}", ext = "html")]
+   | |_____________________________________^
 
 error: missing argument when calling macro `thrice`: `param1`
  --> MissingArgs2.html:3:2
-       "- call thrice() -%}"
+       "- call thrice() -%}{%- endcall -%}"
   --> tests/ui/macro_named_argument.rs:51:21
    |
 51 |   #[template(source = "{%- macro thrice(param1, param2=1) -%}
    |  _____________________^
 52 | | {%- endmacro -%}
-53 | | {%- call thrice() -%}", ext = "html")]
-   | |______________________^
+53 | | {%- call thrice() -%}{%- endcall -%}", ext = "html")]
+   | |_____________________________________^


### PR DESCRIPTION
ref: https://github.com/askama-rs/askama/issues/282#issuecomment-2840581249

I adjusted this quite heavily given the discussion in issue 282. This both adds the caller macro pattern and changes the syntax to align closer to jinja.

`{% call super() %}`  is now `{{ super() }}`

https://jinja.palletsprojects.com/en/stable/templates/#call
https://jinja.palletsprojects.com/en/stable/templates/#child-template

```jinja
{% macro render_dialog(title, class='dialog') -%}
    <div class="{{ class }}">
        <h2>{{ title }}</h2>
        <div class="contents">
            {{ caller() }}
        </div>
    </div>
{%- endmacro %}

{% call render_dialog('Hello World') %}
    This is a simple dialog rendered by using a macro and
    a call block.
{% endcall %}

```
