### PR TITLE
chore: fix tiny wording error in "Calling functions" docs

### DIFF
--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -308,7 +308,7 @@ struct MyTemplate {
 ## Calling functions
 
 If you only provide a function name, askama will assume it's a method. If
-you want to call a method, you will need to use a path instead:
+you want to call a function, you will need to use a path instead:
 
 ```jinja
 {# This is the equivalent of `self.method()`. #}


### PR DESCRIPTION
Currently the doc says:

> If you only provide a function name, askama will assume it's a method. If you want to call a **method**, you will need to use a path instead:

The second "method" doesn't seem like it was intended, as it contradicts the first sentence; it makes much more sense that this was supposed to be a "function" here.