### PR TITLE
generator: fix `ensure_no_named_arguments()` test

### DIFF
--- a/askama_derive/src/generator/filter.rs
+++ b/askama_derive/src/generator/filter.rs
@@ -896,7 +896,7 @@ fn ensure_no_named_arguments(
     node: Span<'_>,
 ) -> Result<(), CompileError> {
     for arg in args {
-        if is_argument_placeholder(arg) {
+        if let Expr::NamedArgument(..) = &**arg {
             return Err(ctx.generate_error(
                 format_args!(
                     "`{}` filter cannot accept named arguments",

--- a/testing/tests/ui/custom-filter-with-named-arg.rs
+++ b/testing/tests/ui/custom-filter-with-named-arg.rs
@@ -1,0 +1,17 @@
+use askama::Template;
+
+mod filters {
+    use askama::Values;
+
+    pub fn do_nothing<'a>(s: &'a str, _: &dyn Values) -> askama::Result<&'a str> {
+        Ok(s)
+    }
+}
+
+#[derive(Template)]
+#[template(source = r#"{{ a | do_nothing(absolutely = "nothing") }}"#, ext = "txt")]
+struct CustomFiltersCannotTakeNamedArguments<'a> {
+    a: &'a str,
+}
+
+fn main() {}

--- a/testing/tests/ui/custom-filter-with-named-arg.stderr
+++ b/testing/tests/ui/custom-filter-with-named-arg.stderr
@@ -1,0 +1,7 @@
+error: `do_nothing` filter cannot accept named arguments
+ --> CustomFiltersCannotTakeNamedArguments.txt:1:3
+       "a | do_nothing(absolutely = \"nothing\") }}"
+  --> tests/ui/custom-filter-with-named-arg.rs:12:21
+   |
+12 | #[template(source = r#"{{ a | do_nothing(absolutely = "nothing") }}"#, ext = "txt")]
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The wrong `Expr` variant was tested.