### PR TITLE
Use `either::Either`

### DIFF
--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -24,6 +24,7 @@ name = "escape"
 harness = false
 
 [dependencies]
+either = { version = "1.15.0", default-features = false }
 itoa = "1.0.11"
 
 # needed by feature "derive"
@@ -61,6 +62,7 @@ serde_json = ["std", "askama_derive?/serde_json", "dep:serde", "dep:serde_json"]
 std = [
     "alloc",
     "askama_derive?/std",
+    "either/std",
     "serde?/std",
     "serde_json?/std",
     "percent-encoding?/std",

--- a/askama/src/either.rs
+++ b/askama/src/either.rs
@@ -1,0 +1,131 @@
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+use core::any::Any;
+use core::fmt;
+
+use either::{Either, for_both};
+
+use crate::{Error, FastWritable, PrimitiveType, Template, Value, Values, filters};
+
+impl<L, R> FastWritable for Either<L, R>
+where
+    L: FastWritable,
+    R: FastWritable,
+{
+    #[inline]
+    fn write_into<W: fmt::Write + ?Sized>(
+        &self,
+        dest: &mut W,
+        values: &dyn Values,
+    ) -> Result<(), Error> {
+        for_both!(self, this => this.write_into(dest, values))
+    }
+}
+
+impl<T: PrimitiveType> PrimitiveType for Either<T, T> {
+    type Value = T::Value;
+
+    #[inline]
+    fn get(&self) -> Self::Value {
+        for_both!(self, this => this.get())
+    }
+}
+
+impl<L, R> Template for Either<L, R>
+where
+    L: Template,
+    R: Template,
+{
+    #[inline]
+    fn render_into_with_values<W: fmt::Write + ?Sized>(
+        &self,
+        writer: &mut W,
+        values: &dyn Values,
+    ) -> Result<(), Error> {
+        for_both!(self, this => this.render_into_with_values(writer, values))
+    }
+
+    #[inline]
+    #[cfg(feature = "alloc")]
+    fn render_with_values(&self, values: &dyn Values) -> Result<String, Error> {
+        // We add a non-default implementation for `render_with_values`,
+        // so a better size_hint is used.
+        let mut buf = String::new();
+        let _ = buf.try_reserve(match self.is_left() {
+            true => L::SIZE_HINT,
+            false => R::SIZE_HINT,
+        });
+        self.render_into_with_values(&mut buf, values)?;
+        Ok(buf)
+    }
+
+    const SIZE_HINT: usize = match (L::SIZE_HINT, R::SIZE_HINT) {
+        (l, r) if l >= r => l,
+        (_, r) => r,
+    };
+}
+
+impl<L, R> Value for Either<L, R>
+where
+    L: Value,
+    R: Value,
+{
+    #[inline]
+    fn ref_any(&self) -> Option<&dyn Any> {
+        for_both!(self, this => this.ref_any())
+    }
+}
+
+impl<L, R> Values for Either<L, R>
+where
+    L: Values,
+    R: Values,
+{
+    #[inline]
+    fn get_value<'a>(&'a self, key: &str) -> Option<&'a dyn Any> {
+        for_both!(self, this => this.get_value(key))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<L, R> filters::AsIndent for Either<L, R>
+where
+    L: filters::AsIndent,
+    R: filters::AsIndent,
+{
+    #[inline]
+    fn as_indent(&self) -> &str {
+        for_both!(self, this => this.as_indent())
+    }
+}
+
+impl<L, R> filters::Escaper for Either<L, R>
+where
+    L: filters::Escaper,
+    R: filters::Escaper,
+{
+    #[inline]
+    fn write_escaped_str<W: fmt::Write>(&self, dest: W, string: &str) -> fmt::Result {
+        for_both!(self, this => this.write_escaped_str(dest, string))
+    }
+}
+
+impl<L, R> filters::HtmlSafe for Either<L, R>
+where
+    L: filters::HtmlSafe,
+    R: filters::HtmlSafe,
+{
+}
+
+impl<L, R> filters::PluralizeCount for Either<L, R>
+where
+    L: filters::PluralizeCount,
+    R: filters::PluralizeCount,
+{
+    type Error = Error;
+
+    #[inline]
+    fn is_singular(&self) -> Result<bool, Self::Error> {
+        for_both!(self, this => this.is_singular().map_err(Into::into))
+    }
+}

--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -66,6 +66,7 @@ extern crate alloc;
 extern crate std;
 
 mod ascii_str;
+mod either;
 mod error;
 pub mod filters;
 #[doc(hidden)]

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -17,6 +17,7 @@ harness = false
 [dependencies]
 askama = { path = "../askama", version = "0.14.0" }
 
+either = "1.15.0"
 serde_json = { version = "1.0", optional = true }
 
 # intentionally shadow the name `::core` to test if the generated code still works fine

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -8,6 +8,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use askama::Template;
 use askama::filters::HtmlSafe;
+use either::Either;
 
 #[test]
 fn test_variables() {
@@ -631,4 +632,23 @@ fn test_concat_inner() {
     }
 
     assert_eq!(ConcatInner { a: "'" }.to_string(), "%3C%27%3E");
+}
+
+#[test]
+fn test_either() {
+    #[derive(Template)]
+    #[template(ext = "html", source = "Left")]
+    struct Left;
+
+    #[derive(Template)]
+    #[template(ext = "html", source = "Right")]
+    struct Right;
+
+    type Direction = Either<Left, Right>;
+    type OtherDirection = Either<Right, Left>;
+
+    assert_eq!(Direction::Left(Left).to_string(), "Left");
+    assert_eq!(Direction::Right(Right).to_string(), "Right");
+    assert_eq!(OtherDirection::Left(Right).to_string(), "Right");
+    assert_eq!(OtherDirection::Right(Left).to_string(), "Left");
 }


### PR DESCRIPTION
This PR lets us implement our traits for `either::Either` instead of implementing `Either` ourself in the form of `Pluralize`.

Probably any non-trivial web project will already (transitively) depend on `either`, be it through `writable`/`icu_*`/`fluent`, `bytes-utils`, `sqlx`, `reqwest` …