### PR TITLE
Ignore fuzzing corpus from source line count

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.html text eol=lf
 *.txt text eol=lf
+fuzzing/fuzz/corpus linguist-vendored


### PR DESCRIPTION
Github's language statistics for the project say that 43% of askama is assembly code. It is not. The heuristic counts our fuzzing corpus as assembly code, and the corpus is quite big.

This PR excludes the corpus from being counted.