### PR TITLE
 Fuzz code generator, too 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -216,6 +216,7 @@ jobs:
       matrix:
         fuzz_target:
           - all
+          - derive
           - filters
           - html
           - parser

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -238,34 +238,34 @@ jobs:
         env:
           RUSTFLAGS: '-Ctarget-feature=-crt-static'
 
-  Cluster-Fuzz:
-    needs: ["Test", "Package", "MSRV"]
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-    steps:
-      - name: Build Fuzzers
-        id: build
-        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
-        with:
-          oss-fuzz-project-name: askama
-          language: rust
-      - name: Run Fuzzers
-        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
-        with:
-          oss-fuzz-project-name: askama
-          language: rust
-          fuzz-seconds: 600
-          output-sarif: true
-      - name: Upload Crash
-        uses: actions/upload-artifact@v4
-        if: failure() && steps.build.outcome == 'success'
-        with:
-          name: artifacts
-          path: ./out/artifacts
-      - name: Upload Sarif
-        if: always() && steps.build.outcome == 'success'
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: cifuzz-sarif/results.sarif
-          checkout_path: cifuzz-sarif
+# Cluster-Fuzz:
+#   needs: ["Test", "Package", "MSRV"]
+#   runs-on: ubuntu-latest
+#   permissions:
+#     security-events: write
+#   steps:
+#     - name: Build Fuzzers
+#       id: build
+#       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+#       with:
+#         oss-fuzz-project-name: askama
+#         language: rust
+#     - name: Run Fuzzers
+#       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+#       with:
+#         oss-fuzz-project-name: askama
+#         language: rust
+#         fuzz-seconds: 600
+#         output-sarif: true
+#     - name: Upload Crash
+#       uses: actions/upload-artifact@v4
+#       if: failure() && steps.build.outcome == 'success'
+#       with:
+#         name: artifacts
+#         path: ./out/artifacts
+#     - name: Upload Sarif
+#       if: always() && steps.build.outcome == 'success'
+#       uses: github/codeql-action/upload-sarif@v3
+#       with:
+#         sarif_file: cifuzz-sarif/results.sarif
+#         checkout_path: cifuzz-sarif

--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -46,6 +46,7 @@ default = [
     "blocks",
     "code-in-doc",
     "config",
+    "external-sources",
     "proc-macro",
     "serde_json",
     "std",
@@ -55,7 +56,8 @@ default = [
 alloc = []
 blocks = ["syn/full"]
 code-in-doc = ["dep:pulldown-cmark"]
-config = ["dep:basic-toml", "dep:serde", "dep:serde_derive", "parser/config"]
+config = ["external-sources", "dep:basic-toml", "dep:serde", "dep:serde_derive", "parser/config"]
+external-sources = []
 proc-macro = ["proc-macro2/proc-macro"]
 serde_json = []
 std = ["alloc"]

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -162,6 +162,7 @@ impl<'a, 'h> Generator<'a, 'h> {
         for path in paths {
             // Skip the fake path of templates defined in rust source.
             let path_is_valid = match self.input.source {
+                #[cfg(feature = "external-sources")]
                 Source::Path(_) => true,
                 Source::Source(_) => path != &*self.input.path,
             };

--- a/askama_derive/src/lib.rs
+++ b/askama_derive/src/lib.rs
@@ -39,7 +39,11 @@ use crate::heritage::{Context, Heritage};
 use crate::input::{AnyTemplateArgs, Print, TemplateArgs, TemplateInput};
 use crate::integration::{Buffer, build_template_enum};
 
+/// [`true`] if and only if [`crate`] is compiled with feature `"external-sources"`.
+pub const CAN_USE_EXTERNAL_SOURCES: bool = cfg!(feature = "external-sources");
+
 #[macro_export]
+#[cfg(feature = "proc-macro")]
 macro_rules! make_derive_template {
     (
         $(#[$meta:meta])*

--- a/askama_macros/Cargo.toml
+++ b/askama_macros/Cargo.toml
@@ -17,8 +17,12 @@ rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 [lib]
 proc-macro = true
 
-[dependencies]
-askama_derive = { package = "askama_derive", version = "=0.14.0", path = "../askama_derive", default-features = false, features = ["proc-macro"] }
+[dependencies.askama_derive]
+package = "askama_derive"
+path = "../askama_derive"
+version = "=0.14.0"
+default-features = false
+features = ["external-sources", "proc-macro"]
 
 [features]
 default = ["config", "derive", "std", "urlencode"]

--- a/fuzzing/fuzz/Cargo.toml
+++ b/fuzzing/fuzz/Cargo.toml
@@ -15,15 +15,27 @@ rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 [dependencies]
 askama = { path = "../../askama", features = ["serde_json"] }
 askama_parser = { path = "../../askama_parser" }
+askama_derive = { path = "../../askama_derive", default-features = false, features = ["serde_json", "std", "urlencode"] }
 
 arbitrary = { version = "1.3.2", features = ["derive"] }
 html-escape = "0.2.13"
 libfuzzer-sys = "0.4.7"
+prettyplease = "0.2.32"
+proc-macro2 = { version = "1.0.95", default-features = false }
+quote = { version = "1.0.40", default-features = false }
+syn = { version = "2.0.101", default-features = false, features = ["full"] }
 thiserror = "2.0.3"
+unicode-ident = "=1.0.18"
 
 [[bin]]
 name = "all"
 path = "fuzz_targets/all.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "derive"
+path = "fuzz_targets/derive.rs"
 test = false
 doc = false
 

--- a/fuzzing/fuzz/fuzz_targets/derive.rs
+++ b/fuzzing/fuzz/fuzz_targets/derive.rs
@@ -1,0 +1,5 @@
+#![no_main]
+
+libfuzzer_sys::fuzz_target!(|data: &[u8]| {
+    let _ = <fuzz::derive::Scenario as fuzz::Scenario>::fuzz(data);
+});

--- a/fuzzing/fuzz/src/derive.rs
+++ b/fuzzing/fuzz/src/derive.rs
@@ -1,0 +1,279 @@
+use std::fmt;
+
+use arbitrary::{Arbitrary, Unstructured};
+use askama_derive::derive_template;
+use prettyplease::unparse;
+use proc_macro2::{Ident, Literal, Span, TokenStream};
+use quote::{ToTokens, TokenStreamExt, quote};
+use syn::token::Comma;
+use syn::{File, parse2};
+use unicode_ident::{is_xid_continue, is_xid_start};
+
+const _: () = {
+    assert!(
+        !askama_derive::CAN_USE_EXTERNAL_SOURCES,
+        "`askama_derive` can use external sources. Denying to fuzz for safety reasons.",
+    );
+};
+
+impl<'a> super::Scenario<'a> for Scenario<'a> {
+    type RunError = syn::Error;
+
+    fn new(data: &'a [u8]) -> Result<Self, arbitrary::Error> {
+        Self::arbitrary_take_rest(Unstructured::new(data))
+    }
+
+    fn run(&self) -> Result<(), Self::RunError> {
+        let input = self.item.to_token_stream();
+        // Any input AST should be parsable by the generator, maybe returning a `compile_error!`.
+        let output = derive_template(input, import_askama);
+        // The generated code should be parsable as rust source.
+        let _: File = parse2(output)?;
+        Ok(())
+    }
+}
+
+fn import_askama() -> TokenStream {
+    quote! {
+        extern crate askama;
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+pub struct Scenario<'a> {
+    item: DeriveItem<'a>,
+}
+
+impl fmt::Display for Scenario<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { item } = self;
+        let ts = quote! {
+            use askama_derive::Ast;
+            use quote::quote;
+
+            #[test]
+            fn test() -> Result<(), syn::Error> {
+                let input = quote! {
+                    #item
+                };
+                let output = derive_template(input, import_askama);
+                let _: syn::File = syn::parse2(output)?;
+                Ok(())
+            }
+
+            fn import_askama() -> TokenStream {
+                quote! {
+                    extern crate askama;
+                }
+            }
+        };
+        f.write_str(&unparse(&parse2(ts).map_err(|_| fmt::Error)?))
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+pub struct DeriveItem<'a> {
+    params: Option<MetaTemplate<'a>>,
+    item: Item<'a>,
+}
+
+impl ToTokens for DeriveItem<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Self { params, item } = self;
+        tokens.extend(quote! {
+            #params
+            #item
+        });
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary)]
+enum Item<'a> {
+    StructItem(StructItem<'a>),
+    Enum(Enum<'a>),
+}
+
+impl ToTokens for Item<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Item::StructItem(s) => tokens.extend(quote! {
+                struct #s
+            }),
+            Item::Enum(s) => s.to_tokens(tokens),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary)]
+enum StructItem<'a> {
+    Empty(Empty<'a>),
+    Struct(Struct<'a>),
+    Tuple(Tuple<'a>),
+}
+
+impl ToTokens for StructItem<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            StructItem::Empty(s) => s.to_tokens(tokens),
+            StructItem::Struct(s) => s.to_tokens(tokens),
+            StructItem::Tuple(s) => s.to_tokens(tokens),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary)]
+struct Empty<'a> {
+    name: Name<'a>,
+}
+
+impl ToTokens for Empty<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.name.to_tokens(tokens);
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary)]
+struct Struct<'a> {
+    name: Name<'a>,
+    fields: Vec<Field<'a>>,
+}
+
+impl ToTokens for Struct<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Self { name, fields } = self;
+        tokens.extend(quote! {
+            #name {
+                #(#fields,)*
+            }
+        });
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary)]
+struct Field<'a> {
+    name: Name<'a>,
+    type_: Name<'a>,
+}
+
+impl ToTokens for Field<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Self { name, type_ } = self;
+        tokens.extend(quote! {
+            #name: #type_
+        });
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary)]
+struct Tuple<'a> {
+    name: Name<'a>,
+    fields: Vec<Name<'a>>,
+}
+
+impl ToTokens for Tuple<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Self { name, fields } = self;
+        tokens.extend(quote! {
+            #name(#(#fields),*)
+        });
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary)]
+struct Enum<'a> {
+    name: Name<'a>,
+    variants: Vec<Variant<'a>>,
+}
+
+impl ToTokens for Enum<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Self { name, variants } = self;
+        tokens.extend(quote! {
+            enum #name {
+                #(#variants),*
+            }
+        });
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary)]
+struct Variant<'a> {
+    params: Option<MetaTemplate<'a>>,
+    item: StructItem<'a>,
+}
+
+impl ToTokens for Variant<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Self { params, item } = self;
+        tokens.extend(quote! {
+            #params
+            #item
+        });
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary)]
+struct MetaTemplate<'a> {
+    ext: Option<Ext<'a>>,
+    source: Option<Source<'a>>,
+}
+
+impl ToTokens for MetaTemplate<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Self { ext, source } = self;
+        let comma = (ext.is_some() && source.is_some()).then(Comma::default);
+        tokens.extend(quote! {
+            #[template(#ext #comma #source)]
+        });
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary)]
+struct Ext<'a>(LiteralString<'a>);
+
+impl ToTokens for Ext<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Self(ext) = self;
+        tokens.extend(quote!(ext = #ext));
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary)]
+struct Source<'a>(LiteralString<'a>);
+
+impl ToTokens for Source<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Self(source) = self;
+        tokens.extend(quote!(source = #source));
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Name<'a>(&'a str);
+
+impl<'a> Arbitrary<'a> for Name<'a> {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let ident = <&str>::arbitrary(u)?;
+        let mut chars = ident.chars();
+        if chars.next().is_some_and(is_xid_start) && chars.all(is_xid_continue) {
+            Ok(Self(ident))
+        } else {
+            Err(arbitrary::Error::IncorrectFormat)
+        }
+    }
+}
+
+impl ToTokens for Name<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append(Ident::new(self.0, Span::call_site()));
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary)]
+struct LiteralString<'a>(&'a str);
+
+impl ToTokens for LiteralString<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append(Literal::string(self.0));
+    }
+}

--- a/fuzzing/fuzz/src/lib.rs
+++ b/fuzzing/fuzz/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod all;
 mod ascii_str;
+pub mod derive;
 pub mod filters;
 pub mod html;
 pub mod parser;
@@ -13,6 +14,9 @@ use std::fmt;
 
 pub const TARGETS: &[(&str, TargetBuilder)] = &[
     ("all", |data| NamedTarget::new::<all::Scenario<'_>>(data)),
+    ("derive", |data| {
+        NamedTarget::new::<derive::Scenario<'_>>(data)
+    }),
     ("filters", |data| {
         NamedTarget::new::<filters::Scenario<'_>>(data)
     }),


### PR DESCRIPTION
This PR adds a fuzzing target for `askama_derive`.

To make sure that the generator does not pull arbitrary files by means of e.g. `{% include %}`, this PR adds the feature `"external-sources"`, which is enabled by default. If it is disabled, the nodes `include`, `import`, `extends`, as well as `#[target(path = ..)]` result in a `CompileError`.

There is no seed corpus, yet. I'll generate it in our [fuzzing-corpus](https://github.com/askama-rs/fuzzing-corpus) after the PR gets merged.