### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,7 @@ jobs:
   Docs:
     strategy:
       matrix:
-        package: [askama, askama_derive, askama_parser]
+        package: [askama, askama_derive, askama_macros, askama_parser]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -38,7 +38,7 @@ percent-encoding = { version = "2.1.0", optional = true, default-features = fals
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-criterion = "0.5"
+criterion = "0.6"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/askama/benches/escape.rs
+++ b/askama/benches/escape.rs
@@ -1,5 +1,7 @@
+use std::hint::black_box;
+
 use askama::filters::{Html, escape};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 criterion_main!(benches);
 criterion_group!(benches, functions);

--- a/askama/benches/to-json.rs
+++ b/askama/benches/to-json.rs
@@ -1,5 +1,7 @@
+use std::hint::black_box;
+
 use askama::Template;
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 criterion_main!(benches);
 criterion_group!(benches, functions);

--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -34,7 +34,7 @@ syn = { version = "2.0.3", default-features = false, features = ["clone-impls", 
 
 [dev-dependencies]
 console = "0.15.8"
-criterion = "0.5"
+criterion = "0.6"
 prettyplease = "0.2.20"
 similar = "2.6.0"
 syn = { version = "2.0.3", features = ["full"] }

--- a/askama_escape/Cargo.toml
+++ b/askama_escape/Cargo.toml
@@ -19,4 +19,4 @@ name = "all"
 harness = false
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = "0.6"

--- a/askama_escape/benches/all.rs
+++ b/askama_escape/benches/all.rs
@@ -1,5 +1,7 @@
+use std::hint::black_box;
+
 use askama_escape::escape_html;
-use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 
 criterion_main!(benches);
 criterion_group!(benches, functions);

--- a/askama_parser/Cargo.toml
+++ b/askama_parser/Cargo.toml
@@ -25,10 +25,10 @@ memchr = "2"
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 unicode-ident = "1.0.12"
-winnow = "0.7.0"
+winnow = { version = "0.7.0", features = ["simd"] }
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = "0.6"
 
 [features]
 config = ["dep:serde", "dep:serde_derive"]

--- a/askama_parser/benches/from_str.rs
+++ b/askama_parser/benches/from_str.rs
@@ -1,5 +1,7 @@
+use std::hint::black_box;
+
 use askama_parser::{Ast, Syntax};
-use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 
 criterion_main!(benches);
 criterion_group!(benches, librustdoc);

--- a/examples/actix-web-app/Cargo.toml
+++ b/examples/actix-web-app/Cargo.toml
@@ -15,7 +15,7 @@ tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 # serde and strum are used to parse (deserialize) and generate (serialize) information
 # between web requests, e.g. to share the selected display language.
 serde = { version = "1.0.217", features = ["derive"] }
-strum = { version = "0.26.3", features = ["derive"] }
+strum = { version = "0.27.1", features = ["derive"] }
 
 # These depenendies are simply used for a better user experience, having access logs in the
 # console, and error messages if anything goes wrong, e.g. if the port is already in use.

--- a/examples/axum-app/Cargo.toml
+++ b/examples/axum-app/Cargo.toml
@@ -15,7 +15,7 @@ tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 # serde and strum are used to parse (deserialize) and generate (serialize) information
 # between web requests, e.g. to share the selected display language.
 serde = { version = "1.0.217", features = ["derive"] }
-strum = { version = "0.26.3", features = ["derive"] }
+strum = { version = "0.27.1", features = ["derive"] }
 
 # These depenendies are simply used for a better user experience, having access logs in the
 # console, and error messages if anything goes wrong, e.g. if the port is already in use.

--- a/examples/poem-app/Cargo.toml
+++ b/examples/poem-app/Cargo.toml
@@ -15,7 +15,7 @@ tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 # serde and strum are used to parse (deserialize) and generate (serialize) information
 # between web requests, e.g. to share the selected display language.
 serde = { version = "1.0.217", features = ["derive"] }
-strum = { version = "0.26.3", features = ["derive"] }
+strum = { version = "0.27.1", features = ["derive"] }
 
 # These depenendies are simply used for a better user experience, having access logs in the
 # console, and error messages if anything goes wrong, e.g. if the port is already in use.

--- a/examples/rocket-app/Cargo.toml
+++ b/examples/rocket-app/Cargo.toml
@@ -13,7 +13,7 @@ rocket = "0.5.1"
 
 # strum is used to parse and serialize information between web requests,
 # e.g. to share the selected display language.
-strum = { version = "0.26.3", features = ["derive"] }
+strum = { version = "0.27.1", features = ["derive"] }
 
 # These depenendies are simply used for a better user experience, having access logs in the
 # console, and error messages if anything goes wrong, e.g. if the port is already in use.

--- a/examples/salvo-app/Cargo.toml
+++ b/examples/salvo-app/Cargo.toml
@@ -9,13 +9,13 @@ publish = false
 # and salvo as your web-framework.
 [dependencies]
 askama = { version = "0.14.0", path = "../../askama" }
-salvo = { version = "0.76.0", default-features = false, features = ["http1", "logging", "server"] }
+salvo = { version = "0.78.0", default-features = false, features = ["http1", "logging", "server"] }
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 
 # serde and strum are used to parse (deserialize) and generate (serialize) information
 # between web requests, e.g. to share the selected display language.
 serde = { version = "1.0.217", features = ["derive"] }
-strum = { version = "0.26.3", features = ["derive"] }
+strum = { version = "0.27.1", features = ["derive"] }
 
 # These depenendies are simply used for a better user experience, having access logs in the
 # console, and error messages if anything goes wrong, e.g. if the port is already in use.

--- a/examples/warp-app/Cargo.toml
+++ b/examples/warp-app/Cargo.toml
@@ -16,7 +16,7 @@ warp = "0.3.7"
 # serde and strum are used to parse (deserialize) and generate (serialize) information
 # between web requests, e.g. to share the selected display language.
 serde = { version = "1.0.217", features = ["derive"] }
-strum = { version = "0.26.3", features = ["derive"] }
+strum = { version = "0.27.1", features = ["derive"] }
 
 # These depenendies are simply used for a better user experience, having access logs in the
 # console, and error messages if anything goes wrong, e.g. if the port is already in use.

--- a/fuzzing/fuzz/src/derive.rs
+++ b/fuzzing/fuzz/src/derive.rs
@@ -48,7 +48,7 @@ impl fmt::Display for Scenario<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self { item } = self;
         let ts = quote! {
-            use askama_derive::Ast;
+            use askama_derive::derive_template;
             use quote::quote;
 
             #[test]

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -26,7 +26,7 @@ core = { package = "intentionally-empty", version = "1.0.0" }
 askama = { path = "../askama", version = "0.14.0", features = ["blocks", "code-in-doc", "serde_json"] }
 
 assert_matches = "1.5.0"
-criterion = "0.5"
+criterion = "0.6"
 phf = { version = "0.11", features = ["macros" ] }
 trybuild = "1.0.100"
 

--- a/testing/benches/normalize_identifier.rs
+++ b/testing/benches/normalize_identifier.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
+use std::hint::black_box;
 use std::iter::FusedIterator;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 criterion_main!(benches);
 criterion_group!(benches, functions);


### PR DESCRIPTION
* Update version-incompatible dependencies in examples.
* Update version-incompatible dev-dependencies.
* Replaced deprecated `criterion::black_box`.
* Add `features = "simd"` to `winnow`. This adds a transitive dependency to `memchr`, on which we already depend on directly.