### PR TITLE
derive: prefix more generated variables with `__askama`

### DIFF
--- a/askama_derive/src/generator/expr.rs
+++ b/askama_derive/src/generator/expr.rs
@@ -363,16 +363,16 @@ impl<'a> Generator<'a, '_> {
         if let Expr::Var(name) = **obj {
             if name == "loop" {
                 if attr.name == "index" {
-                    buf.write("(_loop_item.index + 1)");
+                    buf.write("(__askama_item.index + 1)");
                     return Ok(DisplayWrap::Unwrapped);
                 } else if attr.name == "index0" {
-                    buf.write("_loop_item.index");
+                    buf.write("__askama_item.index");
                     return Ok(DisplayWrap::Unwrapped);
                 } else if attr.name == "first" {
-                    buf.write("(_loop_item.index == 0)");
+                    buf.write("(__askama_item.index == 0)");
                     return Ok(DisplayWrap::Unwrapped);
                 } else if attr.name == "last" {
-                    buf.write("_loop_item.last");
+                    buf.write("__askama_item.last");
                     return Ok(DisplayWrap::Unwrapped);
                 } else {
                     return Err(ctx.generate_error("unknown loop variable", obj.span()));
@@ -476,7 +476,7 @@ impl<'a> Generator<'a, '_> {
                                     if _len == 0 {\
                                         return askama::helpers::core::result::Result::Err(askama::Error::Fmt);\
                                     }\
-                                    _cycle[_loop_item.index % _len]\
+                                    _cycle[__askama_item.index % _len]\
                                 })",
                             );
                             }

--- a/askama_derive/src/generator/node.rs
+++ b/askama_derive/src/generator/node.rs
@@ -566,7 +566,9 @@ impl<'a> Generator<'a, '_> {
             let size_hint1 = this.push_locals(|this| {
                 buf.write("for (");
                 this.visit_target(buf, true, true, &loop_block.var);
-                buf.write(", _loop_item) in askama::helpers::TemplateLoop::new(__askama_iter) {");
+                buf.write(
+                    ", __askama_item) in askama::helpers::TemplateLoop::new(__askama_iter) {",
+                );
 
                 if has_else_nodes {
                     buf.write("__askama_did_loop = true;");

--- a/askama_derive/src/generator/node.rs
+++ b/askama_derive/src/generator/node.rs
@@ -518,7 +518,7 @@ impl<'a> Generator<'a, '_> {
             let flushed = this.write_buf_writable(ctx, buf)?;
             buf.write('{');
             if has_else_nodes {
-                buf.write("let mut _did_loop = false;");
+                buf.write("let mut __askama_did_loop = false;");
             }
             match &*loop_block.iter {
                 Expr::Range(_, _, _) => buf.write(format_args!("let _iter = {expr_code};")),
@@ -559,7 +559,7 @@ impl<'a> Generator<'a, '_> {
                 buf.write(", _loop_item) in askama::helpers::TemplateLoop::new(_iter) {");
 
                 if has_else_nodes {
-                    buf.write("_did_loop = true;");
+                    buf.write("__askama_did_loop = true;");
                 }
                 let mut size_hint1 = this.handle(ctx, &loop_block.body, buf, AstLevel::Nested)?;
                 this.handle_ws(loop_block.ws2);
@@ -570,7 +570,7 @@ impl<'a> Generator<'a, '_> {
 
             let size_hint2;
             if has_else_nodes {
-                buf.write("if !_did_loop {");
+                buf.write("if !__askama_did_loop {");
                 size_hint2 = this.push_locals(|this| {
                     let mut size_hint =
                         this.handle(ctx, &loop_block.else_nodes, buf, AstLevel::Nested)?;

--- a/askama_derive/src/generator/node.rs
+++ b/askama_derive/src/generator/node.rs
@@ -556,7 +556,7 @@ impl<'a> Generator<'a, '_> {
                 this.push_locals(|this| {
                     buf.write("let __askama_iter = __askama_iter.filter(|");
                     this.visit_target(buf, true, true, &loop_block.var);
-                    buf.write("| -> bool {");
+                    buf.write("| -> askama::helpers::core::primitive::bool {");
                     this.visit_expr(ctx, buf, cond)?;
                     buf.write("});");
                     Ok(0)


### PR DESCRIPTION
I want to say "prefix *all* generated variables with `__askama`", but I'm sure I overlooked some variables. :)

Rationale: We deny defining variables with this naming scheme, so this change makes sure that the user does not accidentally shadow a generated variable.

Squash before merging.