### PR TITLE
Prevent `crate` to be used as identifier

### DIFF
--- a/askama_parser/src/expr.rs
+++ b/askama_parser/src/expr.rs
@@ -66,7 +66,7 @@ fn check_expr<'a>(
                 if !crate::can_be_variable_name(name) {
                     return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
                         format!("`{name}` cannot be used as an identifier"),
-                        expr.span,
+                        *name,
                     )));
                 }
             }
@@ -725,7 +725,7 @@ impl<'a> Suffix<'a> {
                     if !crate::can_be_variable_name(name) {
                         Err(winnow::error::ErrMode::Cut(ErrorContext::new(
                             format!("`{name}` cannot be used as an identifier"),
-                            *i,
+                            name,
                         )))
                     } else {
                         Ok(name)

--- a/askama_parser/src/lib.rs
+++ b/askama_parser/src/lib.rs
@@ -1077,6 +1077,11 @@ pub fn strip_common(base: &Path, path: &Path) -> String {
     }
 }
 
+#[inline]
+pub(crate) fn can_be_variable_name(name: &str) -> bool {
+    !matches!(name, "self" | "Self" | "super" | "crate")
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IntKind {
     I8,

--- a/askama_parser/src/target.rs
+++ b/askama_parser/src/target.rs
@@ -4,8 +4,8 @@ use winnow::{ModalParser, Parser};
 
 use crate::{
     CharLit, ErrorContext, Num, ParseErr, ParseResult, PathOrIdentifier, State, StrLit, WithSpan,
-    bool_lit, char_lit, identifier, is_rust_keyword, keyword, num_lit, path_or_identifier, str_lit,
-    ws,
+    bool_lit, can_be_variable_name, char_lit, identifier, is_rust_keyword, keyword, num_lit,
+    path_or_identifier, str_lit, ws,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -108,15 +108,24 @@ impl<'a> Target<'a> {
                 return Ok(Self::Struct(path, targets));
             }
 
-            // If the path only contains one item, we need to check the name.
             if let [name] = path.as_slice() {
-                if !crate::can_be_variable_name(name) {
+                // If the path only contains one item, we need to check the name.
+                if !can_be_variable_name(name) {
+                    return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+                        format!("`{name}` cannot be used as an identifier"),
+                        *name,
+                    )));
+                }
+            } else {
+                // Otherwise we need to check every element but the first.
+                if let Some(name) = path.iter().skip(1).find(|n| !can_be_variable_name(n)) {
                     return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
                         format!("`{name}` cannot be used as an identifier"),
                         *name,
                     )));
                 }
             }
+
             *i = i_before_matching_with;
             return Ok(Self::Path(path));
         }
@@ -213,7 +222,7 @@ fn verify_name<'a>(
             format!("cannot use `{name}` as a name: it is a rust keyword"),
             input,
         )))
-    } else if !crate::can_be_variable_name(name) {
+    } else if !can_be_variable_name(name) {
         Err(winnow::error::ErrMode::Cut(ErrorContext::new(
             format!("`{name}` cannot be used as an identifier"),
             input,

--- a/askama_parser/src/target.rs
+++ b/askama_parser/src/target.rs
@@ -113,7 +113,7 @@ impl<'a> Target<'a> {
                 if !crate::can_be_variable_name(name) {
                     return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
                         format!("`{name}` cannot be used as an identifier"),
-                        i_before_matching_with,
+                        *name,
                     )));
                 }
             }

--- a/testing/tests/matches.rs
+++ b/testing/tests/matches.rs
@@ -300,3 +300,23 @@ fn test_end_when() {
     let tmpl = EndWhen { result: None };
     assert_eq!(tmpl.to_string(), "unprocessed\n");
 }
+
+// This test ensures that `self` can be used as `match` "argument".
+#[test]
+fn test_self_match() {
+    #[derive(Template)]
+    #[template(
+        ext = "html",
+        source = "
+{%- match self %}
+    {%- when Self::A %}A
+    {%- when Self::B %}B
+{%- endmatch %}"
+    )]
+    enum Yeay {
+        A,
+        B,
+    }
+    assert_eq!(Yeay::A.to_string(), "A");
+    assert_eq!(Yeay::B.to_string(), "B");
+}

--- a/testing/tests/ui/assign-to-askama.stderr
+++ b/testing/tests/ui/assign-to-askama.stderr
@@ -303,8 +303,8 @@ error: cannot use `self` as a name: it is a rust keyword
    |                    ^^^^^^^^^^^^^^^^
 
 error: `Self` cannot be used as an identifier
- --> <source attribute>:1:11
-       " %}"
+ --> <source attribute>:1:7
+       "Self %}"
   --> tests/ui/assign-to-askama.rs:55:20
    |
 55 | test_kw!(UpperSelf "{% let Self %}");

--- a/testing/tests/ui/assign-to-askama.stderr
+++ b/testing/tests/ui/assign-to-askama.stderr
@@ -302,9 +302,9 @@ error: cannot use `self` as a name: it is a rust keyword
 54 | test_kw!(LowerSelf "{% let self %}");
    |                    ^^^^^^^^^^^^^^^^
 
-error: when you forward-define a variable, you cannot use a path or enum variant in place of a variable name
- --> <source attribute>:1:2
-       " let Self %}"
+error: `Self` cannot be used as an identifier
+ --> <source attribute>:1:11
+       " %}"
   --> tests/ui/assign-to-askama.rs:55:20
    |
 55 | test_kw!(UpperSelf "{% let Self %}");

--- a/testing/tests/ui/crate_identifier.rs
+++ b/testing/tests/ui/crate_identifier.rs
@@ -100,4 +100,52 @@ struct SmallSelf3 {
 )]
 struct Regression {}
 
+#[derive(Template)]
+#[template(ext = "html", source = "{% match a %}{% when a::b::super %}{% endmatch %}")]
+struct PathElemSuper {
+    a: u8,
+}
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% match a %}{% when self::a::b::super %}{% endmatch %}")]
+struct PathElemSuper2 {
+    a: u8,
+}
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% match a %}{% when a::b::self %}{% endmatch %}")]
+struct PathElemSelf {
+    a: u8,
+}
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% match a %}{% when self::a::b::self %}{% endmatch %}")]
+struct PathElemSelf2 {
+    a: u8,
+}
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% match a %}{% when a::b::crate %}{% endmatch %}")]
+struct PathElemCrate {
+    a: u8,
+}
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% match a %}{% when self::a::b::crate %}{% endmatch %}")]
+struct PathElemCrate2 {
+    a: u8,
+}
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% match a %}{% when a::b::Self %}{% endmatch %}")]
+struct PathElemSelfType {
+    a: u8,
+}
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% match a %}{% when self::a::b::Self %}{% endmatch %}")]
+struct PathElemSelfType2 {
+    a: u8,
+}
+
 fn main() {}

--- a/testing/tests/ui/crate_identifier.rs
+++ b/testing/tests/ui/crate_identifier.rs
@@ -1,0 +1,103 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{{ crate }}")]
+struct Crate;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% if crate == 12 %}{% endif %}")]
+struct Crate2;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% match crate %}{% endmatch %}")]
+struct Crate3;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% let crate %}")]
+struct Crate4;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% let crate = 12 %}")]
+struct Crate5;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{{ self.a.crate }}")]
+struct Crate6 {
+    a: u8,
+}
+
+#[derive(Template)]
+#[template(ext = "html", source = "{{ super }}")]
+struct Super;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% if super == 12 %}{% endif %}")]
+struct Super2;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% match super %}{% endmatch %}")]
+struct Super3;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% let super %}")]
+struct Super4;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% let super = 12 %}")]
+struct Super5;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{{ self.a.super }}")]
+struct Super6 {
+    a: u8,
+}
+
+#[derive(Template)]
+#[template(ext = "html", source = "{{ Self }}")]
+struct Self1;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% if Self == 12 %}{% endif %}")]
+struct Self2;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% match Self %}{% endmatch %}")]
+struct Self3;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% let Self %}")]
+struct Self4;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% let Self = 12 %}")]
+struct Self5;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{{ self.a.Self }}")]
+struct Self6 {
+    a: u8,
+}
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% let self %}")]
+struct SmallSelf;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{% let self = 12 %}")]
+struct SmallSelf2;
+
+#[derive(Template)]
+#[template(ext = "html", source = "{{ self.a.self }}")]
+struct SmallSelf3 {
+    a: u8,
+}
+
+// Regression test for <https://github.com/askama-rs/askama/issues/449>.
+#[derive(Template)]
+#[template(
+    ext = "",
+    source = "{{\u{c}KK3e331<c7}}61/63m3333u7<c0.}}\u{6}\0\u{c}\u{c}{{c/crate<338<c7}}6unsafe/63a3ae\u{c}\u{c}\u{c}%et"
+)]
+struct Regression {}
+
+fn main() {}

--- a/testing/tests/ui/crate_identifier.stderr
+++ b/testing/tests/ui/crate_identifier.stderr
@@ -39,8 +39,8 @@ error: cannot use `crate` as a name: it is a rust keyword
    |                                   ^^^^^^^^^^^^^^^^^^^^^^
 
 error: `crate` cannot be used as an identifier
- --> <source attribute>:1:15
-       " }}"
+ --> <source attribute>:1:10
+       "crate }}"
   --> tests/ui/crate_identifier.rs:24:35
    |
 24 | #[template(ext = "html", source = "{{ self.a.crate }}")]
@@ -87,8 +87,8 @@ error: cannot use `super` as a name: it is a rust keyword
    |                                   ^^^^^^^^^^^^^^^^^^^^^^
 
 error: `super` cannot be used as an identifier
- --> <source attribute>:1:15
-       " }}"
+ --> <source attribute>:1:10
+       "super }}"
   --> tests/ui/crate_identifier.rs:50:35
    |
 50 | #[template(ext = "html", source = "{{ self.a.super }}")]
@@ -119,24 +119,24 @@ error: `Self` cannot be used as an identifier
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `Self` cannot be used as an identifier
- --> <source attribute>:1:11
-       " %}"
+ --> <source attribute>:1:7
+       "Self %}"
   --> tests/ui/crate_identifier.rs:68:35
    |
 68 | #[template(ext = "html", source = "{% let Self %}")]
    |                                   ^^^^^^^^^^^^^^^^
 
 error: `Self` cannot be used as an identifier
- --> <source attribute>:1:11
-       " = 12 %}"
+ --> <source attribute>:1:7
+       "Self = 12 %}"
   --> tests/ui/crate_identifier.rs:72:35
    |
 72 | #[template(ext = "html", source = "{% let Self = 12 %}")]
    |                                   ^^^^^^^^^^^^^^^^^^^^^
 
 error: `Self` cannot be used as an identifier
- --> <source attribute>:1:14
-       " }}"
+ --> <source attribute>:1:10
+       "Self }}"
   --> tests/ui/crate_identifier.rs:76:35
    |
 76 | #[template(ext = "html", source = "{{ self.a.Self }}")]
@@ -159,8 +159,8 @@ error: cannot use `self` as a name: it is a rust keyword
    |                                   ^^^^^^^^^^^^^^^^^^^^^
 
 error: `self` cannot be used as an identifier
- --> <source attribute>:1:14
-       " }}"
+ --> <source attribute>:1:10
+       "self }}"
   --> tests/ui/crate_identifier.rs:90:35
    |
 90 | #[template(ext = "html", source = "{{ self.a.self }}")]

--- a/testing/tests/ui/crate_identifier.stderr
+++ b/testing/tests/ui/crate_identifier.stderr
@@ -173,3 +173,67 @@ error: `crate` cannot be used as an identifier
    |
 99 |     source = "{{\u{c}KK3e331<c7}}61/63m3333u7<c0.}}\u{6}\0\u{c}\u{c}{{c/crate<338<c7}}6unsafe/63a3ae\u{c}\u{c}\u{c}%et"
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `super` cannot be used as an identifier
+ --> <source attribute>:1:27
+       "super %}{% endmatch %}"
+   --> tests/ui/crate_identifier.rs:104:35
+    |
+104 | #[template(ext = "html", source = "{% match a %}{% when a::b::super %}{% endmatch %}")]
+    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `super` cannot be used as an identifier
+ --> <source attribute>:1:33
+       "super %}{% endmatch %}"
+   --> tests/ui/crate_identifier.rs:110:35
+    |
+110 | #[template(ext = "html", source = "{% match a %}{% when self::a::b::super %}{% endmatch %}")]
+    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `self` cannot be used as an identifier
+ --> <source attribute>:1:27
+       "self %}{% endmatch %}"
+   --> tests/ui/crate_identifier.rs:116:35
+    |
+116 | #[template(ext = "html", source = "{% match a %}{% when a::b::self %}{% endmatch %}")]
+    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `self` cannot be used as an identifier
+ --> <source attribute>:1:33
+       "self %}{% endmatch %}"
+   --> tests/ui/crate_identifier.rs:122:35
+    |
+122 | #[template(ext = "html", source = "{% match a %}{% when self::a::b::self %}{% endmatch %}")]
+    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `crate` cannot be used as an identifier
+ --> <source attribute>:1:27
+       "crate %}{% endmatch %}"
+   --> tests/ui/crate_identifier.rs:128:35
+    |
+128 | #[template(ext = "html", source = "{% match a %}{% when a::b::crate %}{% endmatch %}")]
+    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `crate` cannot be used as an identifier
+ --> <source attribute>:1:33
+       "crate %}{% endmatch %}"
+   --> tests/ui/crate_identifier.rs:134:35
+    |
+134 | #[template(ext = "html", source = "{% match a %}{% when self::a::b::crate %}{% endmatch %}")]
+    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `Self` cannot be used as an identifier
+ --> <source attribute>:1:27
+       "Self %}{% endmatch %}"
+   --> tests/ui/crate_identifier.rs:140:35
+    |
+140 | #[template(ext = "html", source = "{% match a %}{% when a::b::Self %}{% endmatch %}")]
+    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `Self` cannot be used as an identifier
+ --> <source attribute>:1:33
+       "Self %}{% endmatch %}"
+   --> tests/ui/crate_identifier.rs:146:35
+    |
+146 | #[template(ext = "html", source = "{% match a %}{% when self::a::b::Self %}{% endmatch %}")]
+    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testing/tests/ui/crate_identifier.stderr
+++ b/testing/tests/ui/crate_identifier.stderr
@@ -1,0 +1,175 @@
+error: `crate` cannot be used as an identifier
+ --> <source attribute>:1:3
+       "crate }}"
+ --> tests/ui/crate_identifier.rs:4:35
+  |
+4 | #[template(ext = "html", source = "{{ crate }}")]
+  |                                   ^^^^^^^^^^^^^
+
+error: `crate` cannot be used as an identifier
+ --> <source attribute>:1:6
+       "crate == 12 %}{% endif %}"
+ --> tests/ui/crate_identifier.rs:8:35
+  |
+8 | #[template(ext = "html", source = "{% if crate == 12 %}{% endif %}")]
+  |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `crate` cannot be used as an identifier
+ --> <source attribute>:1:9
+       "crate %}{% endmatch %}"
+  --> tests/ui/crate_identifier.rs:12:35
+   |
+12 | #[template(ext = "html", source = "{% match crate %}{% endmatch %}")]
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot use `crate` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "crate %}"
+  --> tests/ui/crate_identifier.rs:16:35
+   |
+16 | #[template(ext = "html", source = "{% let crate %}")]
+   |                                   ^^^^^^^^^^^^^^^^^
+
+error: cannot use `crate` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "crate = 12 %}"
+  --> tests/ui/crate_identifier.rs:20:35
+   |
+20 | #[template(ext = "html", source = "{% let crate = 12 %}")]
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^
+
+error: `crate` cannot be used as an identifier
+ --> <source attribute>:1:15
+       " }}"
+  --> tests/ui/crate_identifier.rs:24:35
+   |
+24 | #[template(ext = "html", source = "{{ self.a.crate }}")]
+   |                                   ^^^^^^^^^^^^^^^^^^^^
+
+error: `super` cannot be used as an identifier
+ --> <source attribute>:1:3
+       "super }}"
+  --> tests/ui/crate_identifier.rs:30:35
+   |
+30 | #[template(ext = "html", source = "{{ super }}")]
+   |                                   ^^^^^^^^^^^^^
+
+error: `super` cannot be used as an identifier
+ --> <source attribute>:1:6
+       "super == 12 %}{% endif %}"
+  --> tests/ui/crate_identifier.rs:34:35
+   |
+34 | #[template(ext = "html", source = "{% if super == 12 %}{% endif %}")]
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `super` cannot be used as an identifier
+ --> <source attribute>:1:9
+       "super %}{% endmatch %}"
+  --> tests/ui/crate_identifier.rs:38:35
+   |
+38 | #[template(ext = "html", source = "{% match super %}{% endmatch %}")]
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot use `super` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "super %}"
+  --> tests/ui/crate_identifier.rs:42:35
+   |
+42 | #[template(ext = "html", source = "{% let super %}")]
+   |                                   ^^^^^^^^^^^^^^^^^
+
+error: cannot use `super` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "super = 12 %}"
+  --> tests/ui/crate_identifier.rs:46:35
+   |
+46 | #[template(ext = "html", source = "{% let super = 12 %}")]
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^
+
+error: `super` cannot be used as an identifier
+ --> <source attribute>:1:15
+       " }}"
+  --> tests/ui/crate_identifier.rs:50:35
+   |
+50 | #[template(ext = "html", source = "{{ self.a.super }}")]
+   |                                   ^^^^^^^^^^^^^^^^^^^^
+
+error: `Self` cannot be used as an identifier
+ --> <source attribute>:1:3
+       "Self }}"
+  --> tests/ui/crate_identifier.rs:56:35
+   |
+56 | #[template(ext = "html", source = "{{ Self }}")]
+   |                                   ^^^^^^^^^^^^
+
+error: `Self` cannot be used as an identifier
+ --> <source attribute>:1:6
+       "Self == 12 %}{% endif %}"
+  --> tests/ui/crate_identifier.rs:60:35
+   |
+60 | #[template(ext = "html", source = "{% if Self == 12 %}{% endif %}")]
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `Self` cannot be used as an identifier
+ --> <source attribute>:1:9
+       "Self %}{% endmatch %}"
+  --> tests/ui/crate_identifier.rs:64:35
+   |
+64 | #[template(ext = "html", source = "{% match Self %}{% endmatch %}")]
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `Self` cannot be used as an identifier
+ --> <source attribute>:1:11
+       " %}"
+  --> tests/ui/crate_identifier.rs:68:35
+   |
+68 | #[template(ext = "html", source = "{% let Self %}")]
+   |                                   ^^^^^^^^^^^^^^^^
+
+error: `Self` cannot be used as an identifier
+ --> <source attribute>:1:11
+       " = 12 %}"
+  --> tests/ui/crate_identifier.rs:72:35
+   |
+72 | #[template(ext = "html", source = "{% let Self = 12 %}")]
+   |                                   ^^^^^^^^^^^^^^^^^^^^^
+
+error: `Self` cannot be used as an identifier
+ --> <source attribute>:1:14
+       " }}"
+  --> tests/ui/crate_identifier.rs:76:35
+   |
+76 | #[template(ext = "html", source = "{{ self.a.Self }}")]
+   |                                   ^^^^^^^^^^^^^^^^^^^
+
+error: cannot use `self` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "self %}"
+  --> tests/ui/crate_identifier.rs:82:35
+   |
+82 | #[template(ext = "html", source = "{% let self %}")]
+   |                                   ^^^^^^^^^^^^^^^^
+
+error: cannot use `self` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "self = 12 %}"
+  --> tests/ui/crate_identifier.rs:86:35
+   |
+86 | #[template(ext = "html", source = "{% let self = 12 %}")]
+   |                                   ^^^^^^^^^^^^^^^^^^^^^
+
+error: `self` cannot be used as an identifier
+ --> <source attribute>:1:14
+       " }}"
+  --> tests/ui/crate_identifier.rs:90:35
+   |
+90 | #[template(ext = "html", source = "{{ self.a.self }}")]
+   |                                   ^^^^^^^^^^^^^^^^^^^
+
+error: `crate` cannot be used as an identifier
+ --> <source attribute>:1:41
+       "crate<338<c7}}6unsafe/63a3ae\u{c}\u{c}\u{c}%et"
+  --> tests/ui/crate_identifier.rs:99:14
+   |
+99 |     source = "{{\u{c}KK3e331<c7}}61/63m3333u7<c0.}}\u{6}\0\u{c}\u{c}{{c/crate<338<c7}}6unsafe/63a3ae\u{c}\u{c}\u{c}%et"
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #449.