### PR TITLE
book: upgrading: complete note about filter change

### DIFF
--- a/book/src/upgrading.md
+++ b/book/src/upgrading.md
@@ -15,7 +15,7 @@ list of all changes and improvements that might be useful to you.
 
 * [`FastWritable`](./doc/askama/trait.FastWritable.html) implementations have access to runtime values.
 
-* Custom filters have access to runtime values.
+* Custom filters have access to runtime values, and must add a second `&dyn askama::Values` argument as in [the example](./filters.html#examples).
 
 * `|unique` is a built-in filter; `|titlecase` is an alias for `|title`.
 


### PR DESCRIPTION
commit c6d45e1cdc0f ("Always supply `values` to custom filters") added a second mandatory argument, and it was not obvious what broke on upgrade through the current explanation so write a bit more about it.

--- 
tested the link by fiddling with https://askama.readthedocs.io/en/latest/upgrading.html in the inspector

Thanks for askama!