### PR TITLE
Update `ref` documentation

### DIFF
--- a/book/src/filters.md
+++ b/book/src/filters.md
@@ -90,7 +90,7 @@ Output:
 Dereferences the given argument.
 
 ```jinja
-{% let s = String::from("a") | as_ref %}
+{% let s = String::from("a") | ref %}
 {% if s | deref == String::from("b") %}
 {% endif %}
 ```

--- a/book/src/upgrading.md
+++ b/book/src/upgrading.md
@@ -127,6 +127,8 @@ give you more in-dept explanations: [docs.rs switching jinja template framework 
 
 * The binary operators `|`, `&` and `^` are now called `bitor`, `bitand` and `xor`, resp.
 
+* Filter `as_ref` is now just `ref`
+
 * The feature `"serde-json"` is now called `"serde_json"`.
 
 * The feature `"markdown"` was removed.


### PR DESCRIPTION
Changed `as_ref` in the book to `ref`
Add a line about `ref` renaming to the upgrade guide