### PR TITLE
Correctly escape and reject macro names

### DIFF
--- a/askama_derive/src/generator/expr.rs
+++ b/askama_derive/src/generator/expr.rs
@@ -232,7 +232,19 @@ impl<'a> Generator<'a, '_> {
     }
 
     fn visit_rust_macro(&mut self, buf: &mut Buffer, path: &[&str], args: &str) -> DisplayWrap {
-        self.visit_path(buf, path);
+        let [path @ .., name] = path else {
+            unreachable!("path cannot be empty");
+        };
+        let name = match normalize_identifier(name) {
+            "loop" => "r#loop",
+            name => name,
+        };
+
+        if !path.is_empty() {
+            self.visit_path(buf, path);
+            buf.write("::");
+        }
+        buf.write(name);
         buf.write("!(");
         buf.write(args);
         buf.write(')');

--- a/testing/tests/ui/macro-named-crate.rs
+++ b/testing/tests/ui/macro-named-crate.rs
@@ -1,0 +1,37 @@
+// The names `crate`, `self`, `Self` and `super` cannot be raw identifiers, so they can never
+// be valid macro names.
+
+#[derive(askama::Template)]
+#[template(source = "{{ crate!() }}", ext = "txt")]
+struct MacroCrate;
+
+#[derive(askama::Template)]
+#[template(source = "{{ self!() }}", ext = "txt")]
+struct MacroSelf;
+
+#[derive(askama::Template)]
+#[template(source = "{{ Self!() }}", ext = "txt")]
+struct MacroSelfType;
+
+#[derive(askama::Template)]
+#[template(source = "{{ super!() }}", ext = "txt")]
+struct MacroSuper;
+
+#[derive(askama::Template)]
+#[template(source = "{{ some::path::crate!() }}", ext = "txt")]
+struct MacroPathCrate;
+
+#[derive(askama::Template)]
+#[template(source = "{{ some::path::self!() }}", ext = "txt")]
+struct MacroPathSelf;
+
+#[derive(askama::Template)]
+#[template(source = "{{ some::path::Self!() }}", ext = "txt")]
+struct MacroPathSelfType;
+
+#[derive(askama::Template)]
+#[template(source = "{{ some::path::super!() }}", ext = "txt")]
+struct MacroPathSuper;
+
+fn main() {
+}

--- a/testing/tests/ui/macro-named-crate.stderr
+++ b/testing/tests/ui/macro-named-crate.stderr
@@ -1,0 +1,63 @@
+error: `crate` is not a valid macro name
+ --> <source attribute>:1:3
+       "crate!() }}"
+ --> tests/ui/macro-named-crate.rs:5:21
+  |
+5 | #[template(source = "{{ crate!() }}", ext = "txt")]
+  |                     ^^^^^^^^^^^^^^^^
+
+error: `self` is not a valid macro name
+ --> <source attribute>:1:3
+       "self!() }}"
+ --> tests/ui/macro-named-crate.rs:9:21
+  |
+9 | #[template(source = "{{ self!() }}", ext = "txt")]
+  |                     ^^^^^^^^^^^^^^^
+
+error: `Self` is not a valid macro name
+ --> <source attribute>:1:3
+       "Self!() }}"
+  --> tests/ui/macro-named-crate.rs:13:21
+   |
+13 | #[template(source = "{{ Self!() }}", ext = "txt")]
+   |                     ^^^^^^^^^^^^^^^
+
+error: `super` is not a valid macro name
+ --> <source attribute>:1:3
+       "super!() }}"
+  --> tests/ui/macro-named-crate.rs:17:21
+   |
+17 | #[template(source = "{{ super!() }}", ext = "txt")]
+   |                     ^^^^^^^^^^^^^^^^
+
+error: `crate` is not a valid macro name
+ --> <source attribute>:1:15
+       "crate!() }}"
+  --> tests/ui/macro-named-crate.rs:21:21
+   |
+21 | #[template(source = "{{ some::path::crate!() }}", ext = "txt")]
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `self` is not a valid macro name
+ --> <source attribute>:1:15
+       "self!() }}"
+  --> tests/ui/macro-named-crate.rs:25:21
+   |
+25 | #[template(source = "{{ some::path::self!() }}", ext = "txt")]
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `Self` is not a valid macro name
+ --> <source attribute>:1:15
+       "Self!() }}"
+  --> tests/ui/macro-named-crate.rs:29:21
+   |
+29 | #[template(source = "{{ some::path::Self!() }}", ext = "txt")]
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `super` is not a valid macro name
+ --> <source attribute>:1:15
+       "super!() }}"
+  --> tests/ui/macro-named-crate.rs:33:21
+   |
+33 | #[template(source = "{{ some::path::super!() }}", ext = "txt")]
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Partial fix for <https://github.com/askama-rs/askama/issues/459>.

* `crate!` etc are invalid macro names 
*  Escape macro names like `loop!`

Right now, `true` and `false` are never parsed as identifiers, so a macro `true!()` cannot be called from inside of a template. Actually, I think that's okay. Just don't call the macro that.