### PR TITLE
parser: macro calls need proper tokens

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -238,34 +238,34 @@ jobs:
         env:
           RUSTFLAGS: '-Ctarget-feature=-crt-static'
 
-# Cluster-Fuzz:
-#   needs: ["Test", "Package", "MSRV"]
-#   runs-on: ubuntu-latest
-#   permissions:
-#     security-events: write
-#   steps:
-#     - name: Build Fuzzers
-#       id: build
-#       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
-#       with:
-#         oss-fuzz-project-name: askama
-#         language: rust
-#     - name: Run Fuzzers
-#       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
-#       with:
-#         oss-fuzz-project-name: askama
-#         language: rust
-#         fuzz-seconds: 600
-#         output-sarif: true
-#     - name: Upload Crash
-#       uses: actions/upload-artifact@v4
-#       if: failure() && steps.build.outcome == 'success'
-#       with:
-#         name: artifacts
-#         path: ./out/artifacts
-#     - name: Upload Sarif
-#       if: always() && steps.build.outcome == 'success'
-#       uses: github/codeql-action/upload-sarif@v3
-#       with:
-#         sarif_file: cifuzz-sarif/results.sarif
-#         checkout_path: cifuzz-sarif
+  Cluster-Fuzz:
+    needs: ["Test", "Package", "MSRV"]
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Build Fuzzers
+        id: build
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        with:
+          oss-fuzz-project-name: askama
+          language: rust
+      - name: Run Fuzzers
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        with:
+          oss-fuzz-project-name: askama
+          language: rust
+          fuzz-seconds: 600
+          output-sarif: true
+      - name: Upload Crash
+        uses: actions/upload-artifact@v4
+        if: failure() && steps.build.outcome == 'success'
+        with:
+          name: artifacts
+          path: ./out/artifacts
+      - name: Upload Sarif
+        if: always() && steps.build.outcome == 'success'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: cifuzz-sarif/results.sarif
+          checkout_path: cifuzz-sarif


### PR DESCRIPTION
With this PR invalid tokens inside a macro call `macro_name!(..)` are rejected. Otherwise we might emit invalid code that cannot be parsed by rust. Also update fuzzing corpus to include derive.

Resolves <https://github.com/askama-rs/askama/issues/459>.  
Resolves <https://issues.oss-fuzz.com/issues/418896502>.