### PR TITLE
ci: some fixes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,7 @@ jobs:
   Docs:
     strategy:
       matrix:
-        package: [askama, askama_derive, askama_macros, askama_parser]
+        package: [askama, askama_derive, askama_escape, askama_macros, askama_parser]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -233,7 +233,7 @@ jobs:
           components: rust-src
       - run: curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-quickinstall/releases/download/cargo-fuzz-0.12.0/cargo-fuzz-0.12.0-x86_64-unknown-linux-gnu.tar.gz | tar -xzvvf - -C $HOME/.cargo/bin
       - uses: Swatinem/rust-cache@v2
-      - run: cargo fuzz run ${{ matrix.fuzz_target }} --jobs 4 -- -max_total_time=240
+      - run: cargo fuzz run ${{ matrix.fuzz_target }} --jobs 4 -- -max_total_time=600
         working-directory: fuzzing
         env:
           RUSTFLAGS: '-Ctarget-feature=-crt-static'
@@ -242,6 +242,8 @@ jobs:
     needs: ["Test", "Package", "MSRV"]
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      contents: read
       security-events: write
     steps:
       - name: Build Fuzzers

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -35,4 +35,4 @@ build:
     - CARGO_BUILD_TARGET_DIR=rustdocs RUSTC_BOOTSTRAP=1 cargo docs-rs --target x86_64-unknown-linux-gnu --package askama_escape
     - CARGO_BUILD_TARGET_DIR=rustdocs RUSTC_BOOTSTRAP=1 cargo docs-rs --target x86_64-unknown-linux-gnu --package askama_macros
     - CARGO_BUILD_TARGET_DIR=rustdocs RUSTC_BOOTSTRAP=1 cargo docs-rs --target x86_64-unknown-linux-gnu --package askama_parser
-    - cp --preserve=all --recursive --target-directory $READTHEDOCS_OUTPUT/html/ target/x86_64-unknown-linux-gnu/doc/
+    - cp --preserve=all --recursive --target-directory $READTHEDOCS_OUTPUT/html/ rustdocs/x86_64-unknown-linux-gnu/doc/


### PR DESCRIPTION
* forgot to update source folder in [#473]
* documentation creation was not checked for `askama_escape`
* cluster-fuzz could not [upload sarif file] that contained its outcome
* let all fuzzers run for the same amount of time

[#473]: <https://redirect.github.com/askama-rs/askama/pull/473>
[upload sarif file]: <https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github>