### PR TITLE
Rename `LoopItem::index` to `LoopItem::index0`

### DIFF
--- a/askama/src/helpers.rs
+++ b/askama/src/helpers.rs
@@ -43,11 +43,11 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<(<I as Iterator>::Item, LoopItem)> {
-        self.iter.next().map(|(index, item)| {
+        self.iter.next().map(|(index0, item)| {
             (
                 item,
                 LoopItem {
-                    index,
+                    index0,
                     last: self.iter.peek().is_none(),
                 },
             )
@@ -57,7 +57,7 @@ where
 
 #[derive(Copy, Clone)]
 pub struct LoopItem {
-    pub index: usize,
+    pub index0: usize,
     pub last: bool,
 }
 

--- a/testing/tests/ui/loop-fields.rs
+++ b/testing/tests/ui/loop-fields.rs
@@ -1,0 +1,12 @@
+use askama::Template;
+
+// Fail on unknown `loop` fields
+
+#[derive(Template)]
+#[template(
+    source = "{% for _ in 0..10 %} {{ loop.index1 }} {% endfor %}",
+    ext = "txt"
+)]
+struct UnknownLoopField;
+
+fn main() {}

--- a/testing/tests/ui/loop-fields.stderr
+++ b/testing/tests/ui/loop-fields.stderr
@@ -1,0 +1,7 @@
+error: unknown loop variable `index1`
+ --> UnknownLoopField.txt:1:24
+       "loop.index1 }} {% endfor %}"
+ --> tests/ui/loop-fields.rs:7:14
+  |
+7 |     source = "{% for _ in 0..10 %} {{ loop.index1 }} {% endfor %}",
+  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
That's what the element is called in the template syntax.

Also refactor `Generator::visit_attr()` at bit to make it more readable.  
Also add `__askama` prefix to `_len`.