### PR TITLE
parser: U+10FFFF is the highest Unicode codepoint

### DIFF
--- a/askama_parser/src/lib.rs
+++ b/askama_parser/src/lib.rs
@@ -630,13 +630,19 @@ fn str_lit<'a>(i: &mut &'a str) -> ParseResult<'a, StrLit<'a>> {
                 }
                 'u' => {
                     contains_unicode_escape = true;
-                    let code = delimited('{', take_while(1..6, AsChar::is_hex_digit), '}')
+                    let code = delimited('{', take_while(1..=6, AsChar::is_hex_digit), '}')
                         .parse_next(i)?;
                     match u32::from_str_radix(code, 16).unwrap() {
                         0 => contains_null = true,
                         0xd800..0xe000 => {
                             return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
                                 "unicode escape must not be a surrogate",
+                                start,
+                            )));
+                        }
+                        0x110000.. => {
+                            return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+                                "unicode escape must be at most 10FFFF",
                                 start,
                             )));
                         }

--- a/testing/tests/literal.rs
+++ b/testing/tests/literal.rs
@@ -59,3 +59,26 @@ fn test_prefix_str_literal_in_target() {
     let t = TargetStr { data: *b"hi" };
     assert_eq!(t.render().unwrap(), "bc hoy");
 }
+
+#[test]
+fn test_highest_character() {
+    // U+10FFFF is the highest Unicode codepoint. It must not be reject nor be replaced.
+
+    #[derive(Template)]
+    #[template(
+        ext = "txt",
+        source = "\
+            \u{10ffff}\
+            {{ '\u{10ffff}' }}\
+            {{ \"\u{10ffff}\" }}\
+            {{ '\\u{10ffff}' }}\
+            {{ \"\\u{10ffff}\" }}\
+        "
+    )]
+    struct U10ffff;
+
+    assert_eq!(
+        U10ffff.to_string(),
+        "\u{10ffff}\u{10ffff}\u{10ffff}\u{10ffff}\u{10ffff}"
+    );
+}

--- a/testing/tests/ui/illegal-string-literals.stderr
+++ b/testing/tests/ui/illegal-string-literals.stderr
@@ -62,9 +62,9 @@ error: out of range hex escape
 36 | #[template(ext = "txt", source = r#"{{ "hello \xff world" }}"#)]
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: unclosed or broken string
- --> <source attribute>:1:3
-       "\"hello \\u{128521} world\" }}"
+error: unicode escape must be at most 10FFFF
+ --> <source attribute>:1:4
+       "hello \\u{128521} world\" }}"
   --> tests/ui/illegal-string-literals.rs:64:34
    |
 64 | #[template(ext = "txt", source = r#"{{ "hello \u{128521} world" }}"#)]


### PR DESCRIPTION
Fix a small typo: parsing '\u{123456}` should parse up to 6 characters, inclusively.