### PR TITLE
parser: introduce more types for `Expr` variants

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -581,9 +581,9 @@ fn is_copyable_within_op(expr: &Expr<'_>, within_op: bool) -> bool {
         | Expr::NumLit(_, _)
         | Expr::StrLit(_)
         | Expr::CharLit(_)
-        | Expr::BinOp(_, _, _) => true,
+        | Expr::BinOp(_)
+        | Expr::Range(..) => true,
         Expr::Unary(.., expr) => is_copyable_within_op(expr, true),
-        Expr::Range(..) => true,
         // The result of a call likely doesn't need to be borrowed,
         // as in that case the call is more likely to return a
         // reference in the first place then.

--- a/askama_derive/src/generator/expr.rs
+++ b/askama_derive/src/generator/expr.rs
@@ -80,11 +80,7 @@ impl<'a> Generator<'a, '_> {
                 self.visit_range(ctx, buf, v.op, v.lhs.as_ref(), v.rhs.as_ref())?
             }
             Expr::Group(ref inner) => self.visit_group(ctx, buf, inner)?,
-            Expr::Call {
-                ref path,
-                ref args,
-                ref generics,
-            } => self.visit_call(ctx, buf, path, args, generics)?,
+            Expr::Call(ref v) => self.visit_call(ctx, buf, &v.path, &v.args, &v.generics)?,
             Expr::RustMacro(ref path, args) => self.visit_rust_macro(buf, path, args),
             Expr::Try(ref expr) => self.visit_try(ctx, buf, expr)?,
             Expr::Tuple(ref exprs) => self.visit_tuple(ctx, buf, exprs)?,
@@ -355,7 +351,7 @@ impl<'a> Generator<'a, '_> {
             buf.write("&(");
         }
         match **arg {
-            Expr::Call { ref path, .. } if !matches!(***path, Expr::Path(_)) => {
+            Expr::Call(ref v) if !matches!(*v.path, Expr::Path(_)) => {
                 buf.write('{');
                 self.visit_expr(ctx, buf, arg)?;
                 buf.write('}');

--- a/askama_derive/src/generator/expr.rs
+++ b/askama_derive/src/generator/expr.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use parser::node::CondTest;
-use parser::{Attr, CharLit, CharPrefix, Expr, Filter, Span, StrLit, Target, TyGenerics, WithSpan};
+use parser::{Attr, CharLit, CharPrefix, Expr, Span, StrLit, Target, TyGenerics, WithSpan};
 use quote::quote;
 
 use super::{
@@ -69,11 +69,9 @@ impl<'a> Generator<'a, '_> {
             Expr::Array(ref elements) => self.visit_array(ctx, buf, elements)?,
             Expr::Attr(ref obj, ref attr) => self.visit_attr(ctx, buf, obj, attr)?,
             Expr::Index(ref obj, ref key) => self.visit_index(ctx, buf, obj, key)?,
-            Expr::Filter(Filter {
-                ref name,
-                ref arguments,
-                ref generics,
-            }) => self.visit_filter(ctx, buf, name, arguments, generics, expr.span())?,
+            Expr::Filter(ref v) => {
+                self.visit_filter(ctx, buf, &v.name, &v.arguments, &v.generics, expr.span())?
+            }
             Expr::Unary(op, ref inner) => self.visit_unary(ctx, buf, op, inner)?,
             Expr::BinOp(ref v) => self.visit_binop(ctx, buf, v.op, &v.lhs, &v.rhs)?,
             Expr::Range(ref v) => {

--- a/askama_derive/src/generator/expr.rs
+++ b/askama_derive/src/generator/expr.rs
@@ -76,8 +76,8 @@ impl<'a> Generator<'a, '_> {
             }) => self.visit_filter(ctx, buf, name, arguments, generics, expr.span())?,
             Expr::Unary(op, ref inner) => self.visit_unary(ctx, buf, op, inner)?,
             Expr::BinOp(ref v) => self.visit_binop(ctx, buf, v.op, &v.lhs, &v.rhs)?,
-            Expr::Range(op, ref left, ref right) => {
-                self.visit_range(ctx, buf, op, left.as_deref(), right.as_deref())?
+            Expr::Range(ref v) => {
+                self.visit_range(ctx, buf, v.op, v.lhs.as_ref(), v.rhs.as_ref())?
             }
             Expr::Group(ref inner) => self.visit_group(ctx, buf, inner)?,
             Expr::Call {

--- a/askama_derive/src/generator/node.rs
+++ b/askama_derive/src/generator/node.rs
@@ -8,7 +8,7 @@ use parser::node::{
     Call, Comment, Cond, CondTest, FilterBlock, If, Include, Let, Lit, Loop, Macro, Match,
     Whitespace, Ws,
 };
-use parser::{Expr, Filter, Node, Span, Target, WithSpan};
+use parser::{Expr, Node, Span, Target, WithSpan};
 use rustc_hash::FxBuildHasher;
 
 use super::{
@@ -1641,7 +1641,7 @@ fn is_cacheable(expr: &WithSpan<'_, Expr<'_>>) -> bool {
         Expr::Array(args) => args.iter().all(is_cacheable),
         Expr::Attr(lhs, _) => is_cacheable(lhs),
         Expr::Index(lhs, rhs) => is_cacheable(lhs) && is_cacheable(rhs),
-        Expr::Filter(Filter { arguments, .. }) => arguments.iter().all(is_cacheable),
+        Expr::Filter(v) => v.arguments.iter().all(is_cacheable),
         Expr::Unary(_, arg) => is_cacheable(arg),
         Expr::BinOp(v) => is_cacheable(&v.lhs) && is_cacheable(&v.rhs),
         Expr::IsDefined(_) | Expr::IsNotDefined(_) => true,

--- a/askama_derive/src/generator/node.rs
+++ b/askama_derive/src/generator/node.rs
@@ -199,7 +199,7 @@ impl<'a> Generator<'a, '_> {
             | Expr::Attr(_, _)
             | Expr::Index(_, _)
             | Expr::Filter(_)
-            | Expr::Range(_, _, _)
+            | Expr::Range(_)
             | Expr::Call { .. }
             | Expr::RustMacro(_, _)
             | Expr::Try(_)
@@ -1649,9 +1649,8 @@ fn is_cacheable(expr: &WithSpan<'_, Expr<'_>>) -> bool {
         Expr::Unary(_, arg) => is_cacheable(arg),
         Expr::BinOp(v) => is_cacheable(&v.lhs) && is_cacheable(&v.rhs),
         Expr::IsDefined(_) | Expr::IsNotDefined(_) => true,
-        Expr::Range(_, lhs, rhs) => {
-            lhs.as_ref().is_none_or(|v| is_cacheable(v))
-                && rhs.as_ref().is_none_or(|v| is_cacheable(v))
+        Expr::Range(v) => {
+            v.lhs.as_ref().is_none_or(is_cacheable) && v.rhs.as_ref().is_none_or(is_cacheable)
         }
         Expr::Group(arg) => is_cacheable(arg),
         Expr::Tuple(args) => args.iter().all(is_cacheable),

--- a/askama_parser/src/expr.rs
+++ b/askama_parser/src/expr.rs
@@ -165,7 +165,7 @@ pub enum Expr<'a> {
     Array(Vec<WithSpan<'a, Expr<'a>>>),
     Attr(Box<WithSpan<'a, Expr<'a>>>, Attr<'a>),
     Index(Box<WithSpan<'a, Expr<'a>>>, Box<WithSpan<'a, Expr<'a>>>),
-    Filter(Filter<'a>),
+    Filter(Box<Filter<'a>>),
     As(Box<WithSpan<'a, Expr<'a>>>, &'a str),
     NamedArgument(&'a str, Box<WithSpan<'a, Expr<'a>>>),
     Unary(&'a str, Box<WithSpan<'a, Expr<'a>>>),
@@ -487,11 +487,11 @@ impl<'a> Expr<'a> {
             arguments.insert(0, res);
 
             res = WithSpan::new(
-                Self::Filter(Filter {
+                Self::Filter(Box::new(Filter {
                     name,
                     arguments,
                     generics,
-                }),
+                })),
                 start,
             );
         }

--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -804,7 +804,7 @@ impl<'a> FilterBlock<'a> {
                 name: filter_name,
                 arguments: {
                     let mut args = args.unwrap_or_default();
-                    args.insert(0, WithSpan::new(Expr::Filter(filters), span));
+                    args.insert(0, WithSpan::new(Expr::Filter(Box::new(filters)), span));
                     args
                 },
                 generics,

--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -423,13 +423,13 @@ impl<'a> CondTest<'a> {
             ws(|i: &mut _| {
                 let start = *i;
                 let mut expr = Expr::parse(i, s.level, false)?;
-                if let Expr::BinOp(_, _, ref mut right) = expr.inner {
-                    if matches!(right.inner, Expr::Var("set" | "let")) {
+                if let Expr::BinOp(v) = &mut expr.inner {
+                    if matches!(v.rhs.inner, Expr::Var("set" | "let")) {
                         let _level_guard = s.level.nest(i)?;
-                        *i = right.span.as_suffix_of(start).unwrap();
+                        *i = v.rhs.span.as_suffix_of(start).unwrap();
                         let start_span = Span::from(*i);
                         let new_right = Self::parse_cond(i, s)?;
-                        right.inner = Expr::LetCond(Box::new(WithSpan::new(new_right, start_span)));
+                        v.rhs.inner = Expr::LetCond(Box::new(WithSpan::new(new_right, start_span)));
                     }
                 }
                 Ok(expr)

--- a/askama_parser/src/tests.rs
+++ b/askama_parser/src/tests.rs
@@ -70,36 +70,36 @@ fn test_parse_filter() {
             .nodes,
         vec![Node::Expr(
             Ws(None, None),
-            WithSpan::no_span(Expr::Filter(Filter {
+            WithSpan::no_span(Expr::Filter(Box::new(Filter {
                 name: PathOrIdentifier::Identifier("e"),
                 arguments: vec![WithSpan::no_span(Expr::Var("strvar"))],
                 generics: vec![],
-            })),
+            }))),
         )],
     );
     assert_eq!(
         Ast::from_str("{{ 2|abs }}", None, &syntax).unwrap().nodes,
         vec![Node::Expr(
             Ws(None, None),
-            WithSpan::no_span(Expr::Filter(Filter {
+            WithSpan::no_span(Expr::Filter(Box::new(Filter {
                 name: PathOrIdentifier::Identifier("abs"),
                 arguments: vec![WithSpan::no_span(int_lit("2"))],
                 generics: vec![],
-            })),
+            }))),
         )],
     );
     assert_eq!(
         Ast::from_str("{{ -2|abs }}", None, &syntax).unwrap().nodes,
         vec![Node::Expr(
             Ws(None, None),
-            WithSpan::no_span(Expr::Filter(Filter {
+            WithSpan::no_span(Expr::Filter(Box::new(Filter {
                 name: PathOrIdentifier::Identifier("abs"),
                 arguments: vec![WithSpan::no_span(Expr::Unary(
                     "-",
                     WithSpan::no_span(int_lit("2")).into()
                 ))],
                 generics: vec![],
-            })),
+            }))),
         )],
     );
     assert_eq!(
@@ -108,7 +108,7 @@ fn test_parse_filter() {
             .nodes,
         vec![Node::Expr(
             Ws(None, None),
-            WithSpan::no_span(Expr::Filter(Filter {
+            WithSpan::no_span(Expr::Filter(Box::new(Filter {
                 name: PathOrIdentifier::Identifier("abs"),
                 arguments: vec![WithSpan::no_span(Expr::Group(Box::new(bin_op(
                     "-",
@@ -116,7 +116,7 @@ fn test_parse_filter() {
                     WithSpan::no_span(int_lit("2")),
                 ))))],
                 generics: vec![],
-            })),
+            }))),
         )],
     );
 }
@@ -705,7 +705,7 @@ fn test_odd_calls() {
         Ast::from_str("{{ a(b)|c }}", None, &syntax).unwrap().nodes,
         vec![Node::Expr(
             Ws(None, None),
-            WithSpan::no_span(Expr::Filter(Filter {
+            WithSpan::no_span(Expr::Filter(Box::new(Filter {
                 name: PathOrIdentifier::Identifier("c"),
                 arguments: vec![call(
                     WithSpan::no_span(Expr::Var("a")),
@@ -713,14 +713,14 @@ fn test_odd_calls() {
                     vec![],
                 )],
                 generics: vec![],
-            }))
+            })))
         )]
     );
     assert_eq!(
         Ast::from_str("{{ a(b)| c }}", None, &syntax).unwrap().nodes,
         vec![Node::Expr(
             Ws(None, None),
-            WithSpan::no_span(Expr::Filter(Filter {
+            WithSpan::no_span(Expr::Filter(Box::new(Filter {
                 name: PathOrIdentifier::Identifier("c"),
                 arguments: vec![call(
                     WithSpan::no_span(Expr::Var("a")),
@@ -728,7 +728,7 @@ fn test_odd_calls() {
                     vec![],
                 )],
                 generics: vec![],
-            })),
+            }))),
         )]
     );
 }
@@ -875,24 +875,24 @@ fn test_parse_tuple() {
         Ast::from_str("{{ ()|abs }}", None, &syntax).unwrap().nodes,
         vec![Node::Expr(
             Ws(None, None),
-            WithSpan::no_span(Expr::Filter(Filter {
+            WithSpan::no_span(Expr::Filter(Box::new(Filter {
                 name: PathOrIdentifier::Identifier("abs"),
                 arguments: vec![WithSpan::no_span(Expr::Tuple(vec![]))],
                 generics: vec![],
-            })),
+            }))),
         )],
     );
     assert_eq!(
         Ast::from_str("{{ (1)|abs }}", None, &syntax).unwrap().nodes,
         vec![Node::Expr(
             Ws(None, None),
-            WithSpan::no_span(Expr::Filter(Filter {
+            WithSpan::no_span(Expr::Filter(Box::new(Filter {
                 name: PathOrIdentifier::Identifier("abs"),
                 arguments: vec![WithSpan::no_span(Expr::Group(Box::new(WithSpan::no_span(
                     int_lit("1")
                 ))))],
                 generics: vec![],
-            })),
+            }))),
         )],
     );
     assert_eq!(
@@ -901,13 +901,13 @@ fn test_parse_tuple() {
             .nodes,
         vec![Node::Expr(
             Ws(None, None),
-            WithSpan::no_span(Expr::Filter(Filter {
+            WithSpan::no_span(Expr::Filter(Box::new(Filter {
                 name: PathOrIdentifier::Identifier("abs"),
                 arguments: vec![WithSpan::no_span(Expr::Tuple(vec![WithSpan::no_span(
                     int_lit("1")
                 )]))],
                 generics: vec![],
-            })),
+            }))),
         )],
     );
     assert_eq!(
@@ -916,14 +916,14 @@ fn test_parse_tuple() {
             .nodes,
         vec![Node::Expr(
             Ws(None, None),
-            WithSpan::no_span(Expr::Filter(Filter {
+            WithSpan::no_span(Expr::Filter(Box::new(Filter {
                 name: PathOrIdentifier::Identifier("abs"),
                 arguments: vec![WithSpan::no_span(Expr::Tuple(vec![
                     WithSpan::no_span(int_lit("1")),
                     WithSpan::no_span(int_lit("2"))
                 ]))],
                 generics: vec![],
-            })),
+            }))),
         )],
     );
 }
@@ -1013,22 +1013,22 @@ fn test_parse_array() {
         Ast::from_str("{{ []|foo }}", None, &syntax).unwrap().nodes,
         vec![Node::Expr(
             Ws(None, None),
-            WithSpan::no_span(Expr::Filter(Filter {
+            WithSpan::no_span(Expr::Filter(Box::new(Filter {
                 name: PathOrIdentifier::Identifier("foo"),
                 arguments: vec![WithSpan::no_span(Expr::Array(vec![]))],
                 generics: vec![],
-            }))
+            })))
         )],
     );
     assert_eq!(
         Ast::from_str("{{ []| foo }}", None, &syntax).unwrap().nodes,
         vec![Node::Expr(
             Ws(None, None),
-            WithSpan::no_span(Expr::Filter(Filter {
+            WithSpan::no_span(Expr::Filter(Box::new(Filter {
                 name: PathOrIdentifier::Identifier("foo"),
                 arguments: vec![WithSpan::no_span(Expr::Array(vec![]))],
                 generics: vec![],
-            }))
+            })))
         )],
     );
 
@@ -1333,11 +1333,11 @@ fn test_filter_with_path() {
             .nodes,
         vec![Node::Expr(
             Ws(None, None),
-            WithSpan::no_span(Expr::Filter(Filter {
+            WithSpan::no_span(Expr::Filter(Box::new(Filter {
                 name: PathOrIdentifier::Path(vec!["", "e"]),
                 arguments: vec![WithSpan::no_span(Expr::Var("strvar"))],
                 generics: vec![],
-            })),
+            }))),
         )],
     );
     assert_eq!(
@@ -1346,11 +1346,11 @@ fn test_filter_with_path() {
             .nodes,
         vec![Node::Expr(
             Ws(None, None),
-            WithSpan::no_span(Expr::Filter(Filter {
+            WithSpan::no_span(Expr::Filter(Box::new(Filter {
                 name: PathOrIdentifier::Path(vec!["", "e", "f"]),
                 arguments: vec![WithSpan::no_span(Expr::Var("strvar"))],
                 generics: vec![],
-            })),
+            }))),
         )],
     );
     assert_eq!(
@@ -1359,11 +1359,11 @@ fn test_filter_with_path() {
             .nodes,
         vec![Node::Expr(
             Ws(None, None),
-            WithSpan::no_span(Expr::Filter(Filter {
+            WithSpan::no_span(Expr::Filter(Box::new(Filter {
                 name: PathOrIdentifier::Path(vec!["e", "f"]),
                 arguments: vec![WithSpan::no_span(Expr::Var("strvar"))],
                 generics: vec![],
-            })),
+            }))),
         )],
     );
     assert_eq!(
@@ -1372,11 +1372,11 @@ fn test_filter_with_path() {
             .nodes,
         vec![Node::Expr(
             Ws(None, None),
-            WithSpan::no_span(Expr::Filter(Filter {
+            WithSpan::no_span(Expr::Filter(Box::new(Filter {
                 name: PathOrIdentifier::Path(vec!["e", "f"]),
                 arguments: vec![WithSpan::no_span(Expr::Var("strvar"))],
                 generics: vec![],
-            })),
+            }))),
         )],
     );
     assert_eq!(


### PR DESCRIPTION
This makes the code prettier and `Expr` smaller.