### PR TITLE
parser: un-inline error message generation

### DIFF
--- a/askama_parser/src/lib.rs
+++ b/askama_parser/src/lib.rs
@@ -405,10 +405,7 @@ fn num_lit<'a>(i: &mut &'a str) -> ParseResult<'a, Num<'a>> {
         {
             Ok(value)
         } else {
-            Err(ErrMode::Cut(ErrorContext::new(
-                format!("unknown {kind} suffix `{suffix}`"),
-                start,
-            )))
+            cut_error!(format!("unknown {kind} suffix `{suffix}`"), start)
         }
     }
 
@@ -421,10 +418,7 @@ fn num_lit<'a>(i: &mut &'a str) -> ParseResult<'a, Num<'a>> {
             .parse_next(i)?;
         match opt(separated_digits(base, false)).parse_next(i)? {
             Some(_) => Ok(()),
-            None => Err(ErrMode::Cut(ErrorContext::new(
-                format!("expected digits after `{kind}`"),
-                start,
-            ))),
+            None => cut_error!(format!("expected digits after `{kind}`"), start),
         }
     });
 
@@ -436,10 +430,12 @@ fn num_lit<'a>(i: &mut &'a str) -> ParseResult<'a, Num<'a>> {
             let (kind, op) = (one_of(['e', 'E']), opt(one_of(['+', '-']))).parse_next(i)?;
             match opt(separated_digits(10, op.is_none())).parse_next(i)? {
                 Some(_) => Ok(()),
-                None => Err(ErrMode::Cut(ErrorContext::new(
-                    format!("expected decimal digits, `+` or `-` after exponent `{kind}`"),
-                    start,
-                ))),
+                None => {
+                    cut_error!(
+                        format!("expected decimal digits, `+` or `-` after exponent `{kind}`"),
+                        start,
+                    )
+                }
             }
         })
         .parse_next(i)?;
@@ -578,12 +574,12 @@ fn str_lit<'a>(i: &mut &'a str) -> ParseResult<'a, StrLit<'a>> {
                     if has_lf {
                         continue;
                     } else {
-                        return Err(ErrMode::Cut(ErrorContext::new(
+                        return cut_error!(
                             "a bare CR (Mac linebreak) is not allowed in string literals, \
                             use NL (Unix linebreak) or CRNL (Windows linebreak) instead, \
                             or type `\\r` explicitly",
                             start,
-                        )));
+                        );
                     }
                 }
                 Sequence::Close => break,
@@ -611,16 +607,10 @@ fn str_lit<'a>(i: &mut &'a str) -> ParseResult<'a, StrLit<'a>> {
                     match u32::from_str_radix(code, 16).unwrap() {
                         0 => contains_null = true,
                         0xd800..0xe000 => {
-                            return Err(ErrMode::Cut(ErrorContext::new(
-                                "unicode escape must not be a surrogate",
-                                start,
-                            )));
+                            return cut_error!("unicode escape must not be a surrogate", start);
                         }
                         0x110000.. => {
-                            return Err(ErrMode::Cut(ErrorContext::new(
-                                "unicode escape must be at most 10FFFF",
-                                start,
-                            )));
+                            return cut_error!("unicode escape must be at most 10FFFF", start);
                         }
                         128.. => contains_unicode_character = true,
                         _ => {}
@@ -653,10 +643,7 @@ fn str_lit<'a>(i: &mut &'a str) -> ParseResult<'a, StrLit<'a>> {
 
     let lit = opt(terminated(inner.with_taken(), '"')).parse_next(i)?;
     let Some((mut lit, content)) = lit else {
-        return Err(ErrMode::Cut(ErrorContext::new(
-            "unclosed or broken string",
-            start,
-        )));
+        return cut_error!("unclosed or broken string", start);
     };
     lit.content = content;
     lit.prefix = prefix;
@@ -677,7 +664,7 @@ fn str_lit<'a>(i: &mut &'a str) -> ParseResult<'a, StrLit<'a>> {
         None => lit.contains_high_ascii.then_some("out of range hex escape"),
     };
     if let Some(msg) = msg {
-        return Err(ErrMode::Cut(ErrorContext::new(msg, start)));
+        return cut_error!(msg, start);
     }
 
     not_suffix_with_hash(i)?;
@@ -686,10 +673,10 @@ fn str_lit<'a>(i: &mut &'a str) -> ParseResult<'a, StrLit<'a>> {
 
 fn not_suffix_with_hash<'a>(i: &mut &'a str) -> ParseResult<'a, ()> {
     if let Some(suffix) = opt((identifier, '#').take()).parse_next(i)? {
-        return Err(ErrMode::Cut(ErrorContext::new(
+        return cut_error!(
             "you are missing a space to separate two string literals",
             suffix,
-        )));
+        );
     }
     Ok(())
 }
@@ -704,10 +691,10 @@ fn str_lit_without_prefix<'a>(i: &mut &'a str) -> ParseResult<'a> {
         None => None,
     };
     if let Some(kind) = kind {
-        return Err(ErrMode::Cut(ErrorContext::new(
+        return cut_error!(
             format!("expected an unprefixed normal string, not a {kind}"),
             start,
-        )));
+        );
     }
 
     Ok(lit.content)
@@ -740,15 +727,12 @@ fn char_lit<'a>(i: &mut &'a str) -> ParseResult<'a, CharLit<'a>> {
 
     let Some(s) = s else {
         i.reset(&start);
-        return Err(ErrMode::Cut(ErrorContext::new(
-            "empty character literal",
-            *i,
-        )));
+        return cut_error!("empty character literal", *i);
     };
     let mut is = s;
     let Ok(c) = Char::parse(&mut is) else {
         i.reset(&start);
-        return Err(ErrMode::Cut(ErrorContext::new("invalid character", *i)));
+        return cut_error!("invalid character", *i);
     };
 
     let (nb, max_value, err1, err2) = match c {
@@ -776,11 +760,11 @@ fn char_lit<'a>(i: &mut &'a str) -> ParseResult<'a, CharLit<'a>> {
 
     let Ok(nb) = u32::from_str_radix(nb, 16) else {
         i.reset(&start);
-        return Err(ErrMode::Cut(ErrorContext::new(err1, *i)));
+        return cut_error!(err1, *i);
     };
     if nb > max_value {
         i.reset(&start);
-        return Err(ErrMode::Cut(ErrorContext::new(err2, *i)));
+        return cut_error!(err2, *i);
     }
 
     Ok(CharLit {
@@ -1117,17 +1101,16 @@ impl Level<'_> {
                 count: 1,
             })
         } else {
-            Err(Self::_fail(i))
+            Self::_fail(i)
         }
     }
 
-    #[cold]
-    #[inline(never)]
-    fn _fail(i: &str) -> ParseErr<'_> {
-        ErrMode::Cut(ErrorContext::new(
+    #[inline(always)]
+    fn _fail<T>(i: &str) -> ParseResult<'_, T> {
+        cut_error!(
             "your template code is too deeply nested, or the last expression is too complex",
             i,
-        ))
+        )
     }
 }
 
@@ -1153,7 +1136,7 @@ impl LevelGuard<'_> {
             self.count += 1;
             Ok(())
         } else {
-            Err(Level::_fail(i))
+            Level::_fail(i)
         }
     }
 }
@@ -1435,6 +1418,30 @@ fn is_rust_keyword(ident: &str) -> bool {
         }
     }
     false
+}
+
+macro_rules! cut_error {
+    ($message:expr, $span:expr $(,)?) => {{
+        use ::std::convert::Into;
+        use ::std::option::Option::Some;
+
+        $crate::cut_context_err(
+            #[cold]
+            #[inline(always)]
+            move || $crate::ErrorContext {
+                span: Into::into($span),
+                message: Some(Into::into($message)),
+            },
+        )
+    }};
+}
+
+pub(crate) use cut_error;
+
+#[cold]
+#[inline(never)]
+fn cut_context_err<'a, T>(gen_err: impl FnOnce() -> ErrorContext<'a>) -> ParseResult<'a, T> {
+    Err(ErrMode::Cut(gen_err()))
 }
 
 #[cfg(not(windows))]

--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -5,6 +5,7 @@ use winnow::combinator::{
     alt, cut_err, delimited, eof, fail, not, opt, peek, preceded, repeat, separated,
     separated_pair, terminated,
 };
+use winnow::error::ErrMode;
 use winnow::stream::Stream as _;
 use winnow::token::{any, rest, take_until};
 use winnow::{ModalParser, Parser};
@@ -41,9 +42,7 @@ impl<'a> Node<'a> {
         let result = match (|i: &mut _| Self::many(i, s)).parse_next(i) {
             Ok(result) => result,
             Err(err) => {
-                if let winnow::error::ErrMode::Backtrack(err) | winnow::error::ErrMode::Cut(err) =
-                    &err
-                {
+                if let ErrMode::Backtrack(err) | ErrMode::Cut(err) = &err {
                     if err.message.is_none() {
                         *i = start;
                         if let Some(mut span) = err.span.as_suffix_of(i) {
@@ -57,7 +56,7 @@ impl<'a> Node<'a> {
         opt(|i: &mut _| unexpected_tag(i, s)).parse_next(i)?;
         let is_eof = opt(eof).parse_next(i)?;
         if is_eof.is_none() {
-            return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+            return Err(ErrMode::Cut(ErrorContext::new(
                 "cannot parse entire template\n\
                  you should never encounter this error\n\
                  please report this error to <https://github.com/askama-rs/askama/issues>",
@@ -133,7 +132,7 @@ impl<'a> Node<'a> {
         let start = *i;
         let (pws, _, nws) = p.parse_next(i)?;
         if !s.is_in_loop() {
-            return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+            return Err(ErrMode::Cut(ErrorContext::new(
                 "you can only `break` inside a `for` loop",
                 start,
             )));
@@ -151,7 +150,7 @@ impl<'a> Node<'a> {
         let start = *i;
         let (pws, _, nws) = p.parse_next(i)?;
         if !s.is_in_loop() {
-            return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+            return Err(ErrMode::Cut(ErrorContext::new(
                 "you can only `continue` inside a `for` loop",
                 start,
             )));
@@ -223,9 +222,7 @@ fn cut_node<'a, O>(
     move |i: &mut &'a str| {
         let start = *i;
         let result = inner.parse_next(i);
-        if let Err(winnow::error::ErrMode::Cut(err) | winnow::error::ErrMode::Backtrack(err)) =
-            &result
-        {
+        if let Err(ErrMode::Cut(err) | ErrMode::Backtrack(err)) = &result {
             if err.message.is_none() {
                 *i = start;
                 if let Some(mut span) = err.span.as_suffix_of(i) {
@@ -259,7 +256,7 @@ fn unexpected_raw_tag<'a>(kind: Option<&'static str>, i: &mut &'a str) -> ParseR
         tag if tag.starts_with("end") => format!("unexpected closing tag `{tag}`"),
         tag => format!("unknown node `{tag}`"),
     };
-    Err(winnow::error::ErrMode::Cut(ErrorContext::new(msg, *i)))
+    Err(ErrMode::Cut(ErrorContext::new(msg, *i)))
 }
 
 #[derive(Debug, PartialEq)]
@@ -491,7 +488,7 @@ fn check_block_start<'a>(
     expected: &str,
 ) -> ParseResult<'a, ()> {
     if i.is_empty() {
-        return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+        return Err(ErrMode::Cut(ErrorContext::new(
             format!("expected `{expected}` to terminate `{node}` node, found nothing"),
             start,
         )));
@@ -625,7 +622,7 @@ fn check_duplicated_name<'a>(
     i: &'a str,
 ) -> Result<(), crate::ParseErr<'a>> {
     if !names.insert(arg_name) {
-        return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+        return Err(ErrMode::Cut(ErrorContext::new(
             format!("duplicated argument `{arg_name}`"),
             i,
         )));
@@ -661,7 +658,7 @@ impl<'a> Macro<'a> {
             .parse_next(i)?;
             match args {
                 Some((args, Some(_))) => Ok(args),
-                Some((_, None)) => Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+                Some((_, None)) => Err(ErrMode::Cut(ErrorContext::new(
                     "expected `)` to close macro argument list",
                     *i,
                 ))),
@@ -685,7 +682,7 @@ impl<'a> Macro<'a> {
         );
         let (pws1, _, (name, params, nws1, _)) = start.parse_next(i)?;
         if is_rust_keyword(name) {
-            return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+            return Err(ErrMode::Cut(ErrorContext::new(
                 format!("'{name}' is not a valid name for a macro"),
                 start_s,
             )));
@@ -701,7 +698,7 @@ impl<'a> Macro<'a> {
                     for (new_arg_name, default_value) in iter.by_ref() {
                         check_duplicated_name(&mut names, new_arg_name, start_s)?;
                         if default_value.is_none() {
-                            return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+                            return Err(ErrMode::Cut(ErrorContext::new(
                                 format!(
                                     "all arguments following `{arg_name}` should have a default \
                                          value, `{new_arg_name}` doesn't have a default value"
@@ -880,7 +877,7 @@ impl<'a> Call<'a> {
 
             match args {
                 Some((args, Some(_))) => Ok(args),
-                Some((_, None)) => Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+                Some((_, None)) => Err(ErrMode::Cut(ErrorContext::new(
                     "expected `)` to close call argument list",
                     *i,
                 ))),
@@ -992,7 +989,7 @@ impl<'a> Match<'a> {
             arms.push(arm);
         }
         if arms.is_empty() {
-            return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+            return Err(ErrMode::Cut(ErrorContext::new(
                 "`match` nodes must contain at least one `when` node and/or an `else` case",
                 start,
             )));
@@ -1082,7 +1079,7 @@ fn check_end_name<'a>(
         return Ok(end_name);
     }
 
-    Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+    Err(ErrMode::Cut(ErrorContext::new(
         match name.is_empty() && !end_name.is_empty() {
             true => format!("unexpected name `{end_name}` in `end{kind}` tag for unnamed `{kind}`"),
             false => format!("expected name `{name}` in `end{kind}` tag, found `{end_name}`"),
@@ -1234,7 +1231,7 @@ impl<'a> Let<'a> {
                 }
             };
             if let Some(kind) = kind {
-                return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+                return Err(ErrMode::Cut(ErrorContext::new(
                     format!(
                         "when you forward-define a variable, you cannot use {kind} in place of \
                          a variable name"
@@ -1244,7 +1241,7 @@ impl<'a> Let<'a> {
             }
         }
         if is_mut.is_some() && !matches!(var, Target::Name(_)) {
-            return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+            return Err(ErrMode::Cut(ErrorContext::new(
                 "you can only use the `mut` keyword with a variable name",
                 start,
             )));
@@ -1407,7 +1404,7 @@ impl<'a> Comment<'a> {
 
         let mut ws = Ws(None, None);
         if content.len() == 1 && matches!(content, "-" | "+" | "~") {
-            return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+            return Err(ErrMode::Cut(ErrorContext::new(
                 format!(
                     "ambiguous whitespace stripping\n\
                      use `{}{content} {content}{}` to apply the same whitespace stripping on both \
@@ -1442,7 +1439,7 @@ fn end_node<'a, 'g: 'a>(
             Ok(actual)
         } else if actual.starts_with("end") {
             i.reset(&start);
-            Err(winnow::error::ErrMode::Cut(ErrorContext::new(
+            Err(ErrMode::Cut(ErrorContext::new(
                 format!("expected `{expected}` to terminate `{node}` node, found `{actual}`"),
                 *i,
             )))

--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -11,8 +11,8 @@ use winnow::token::{any, rest, take_until};
 use winnow::{ModalParser, Parser};
 
 use crate::{
-    ErrorContext, Expr, Filter, ParseResult, Span, State, Target, WithSpan, filter, identifier,
-    is_rust_keyword, keyword, skip_ws0, str_lit_without_prefix, ws,
+    ErrorContext, Expr, Filter, ParseResult, Span, State, Target, WithSpan, cut_error, filter,
+    identifier, is_rust_keyword, keyword, skip_ws0, str_lit_without_prefix, ws,
 };
 
 #[derive(Debug, PartialEq)]
@@ -56,12 +56,12 @@ impl<'a> Node<'a> {
         opt(|i: &mut _| unexpected_tag(i, s)).parse_next(i)?;
         let is_eof = opt(eof).parse_next(i)?;
         if is_eof.is_none() {
-            return Err(ErrMode::Cut(ErrorContext::new(
+            return cut_error!(
                 "cannot parse entire template\n\
                  you should never encounter this error\n\
                  please report this error to <https://github.com/askama-rs/askama/issues>",
                 *i,
-            )));
+            );
         }
         Ok(result)
     }
@@ -132,10 +132,7 @@ impl<'a> Node<'a> {
         let start = *i;
         let (pws, _, nws) = p.parse_next(i)?;
         if !s.is_in_loop() {
-            return Err(ErrMode::Cut(ErrorContext::new(
-                "you can only `break` inside a `for` loop",
-                start,
-            )));
+            return cut_error!("you can only `break` inside a `for` loop", start);
         }
         Ok(Self::Break(WithSpan::new(Ws(pws, nws), start)))
     }
@@ -150,10 +147,7 @@ impl<'a> Node<'a> {
         let start = *i;
         let (pws, _, nws) = p.parse_next(i)?;
         if !s.is_in_loop() {
-            return Err(ErrMode::Cut(ErrorContext::new(
-                "you can only `continue` inside a `for` loop",
-                start,
-            )));
+            return cut_error!("you can only `continue` inside a `for` loop", start);
         }
         Ok(Self::Continue(WithSpan::new(Ws(pws, nws), start)))
     }
@@ -256,7 +250,7 @@ fn unexpected_raw_tag<'a>(kind: Option<&'static str>, i: &mut &'a str) -> ParseR
         tag if tag.starts_with("end") => format!("unexpected closing tag `{tag}`"),
         tag => format!("unknown node `{tag}`"),
     };
-    Err(ErrMode::Cut(ErrorContext::new(msg, *i)))
+    cut_error!(msg, *i)
 }
 
 #[derive(Debug, PartialEq)]
@@ -488,10 +482,10 @@ fn check_block_start<'a>(
     expected: &str,
 ) -> ParseResult<'a, ()> {
     if i.is_empty() {
-        return Err(ErrMode::Cut(ErrorContext::new(
+        return cut_error!(
             format!("expected `{expected}` to terminate `{node}` node, found nothing"),
             start,
-        )));
+        );
     }
     (|i: &mut _| s.tag_block_start(i)).parse_next(i)
 }
@@ -622,10 +616,7 @@ fn check_duplicated_name<'a>(
     i: &'a str,
 ) -> Result<(), crate::ParseErr<'a>> {
     if !names.insert(arg_name) {
-        return Err(ErrMode::Cut(ErrorContext::new(
-            format!("duplicated argument `{arg_name}`"),
-            i,
-        )));
+        return cut_error!(format!("duplicated argument `{arg_name}`"), i);
     }
     Ok(())
 }
@@ -658,10 +649,7 @@ impl<'a> Macro<'a> {
             .parse_next(i)?;
             match args {
                 Some((args, Some(_))) => Ok(args),
-                Some((_, None)) => Err(ErrMode::Cut(ErrorContext::new(
-                    "expected `)` to close macro argument list",
-                    *i,
-                ))),
+                Some((_, None)) => cut_error!("expected `)` to close macro argument list", *i),
                 None => Ok(None),
             }
         };
@@ -682,10 +670,7 @@ impl<'a> Macro<'a> {
         );
         let (pws1, _, (name, params, nws1, _)) = start.parse_next(i)?;
         if is_rust_keyword(name) {
-            return Err(ErrMode::Cut(ErrorContext::new(
-                format!("'{name}' is not a valid name for a macro"),
-                start_s,
-            )));
+            return cut_error!(format!("'{name}' is not a valid name for a macro"), start_s);
         }
 
         if let Some(ref params) = params {
@@ -698,13 +683,13 @@ impl<'a> Macro<'a> {
                     for (new_arg_name, default_value) in iter.by_ref() {
                         check_duplicated_name(&mut names, new_arg_name, start_s)?;
                         if default_value.is_none() {
-                            return Err(ErrMode::Cut(ErrorContext::new(
+                            return cut_error!(
                                 format!(
                                     "all arguments following `{arg_name}` should have a default \
                                          value, `{new_arg_name}` doesn't have a default value"
                                 ),
                                 start_s,
-                            )));
+                            );
                         }
                     }
                 }
@@ -877,10 +862,7 @@ impl<'a> Call<'a> {
 
             match args {
                 Some((args, Some(_))) => Ok(args),
-                Some((_, None)) => Err(ErrMode::Cut(ErrorContext::new(
-                    "expected `)` to close call argument list",
-                    *i,
-                ))),
+                Some((_, None)) => cut_error!("expected `)` to close call argument list", *i),
                 None => Ok(None),
             }
         };
@@ -989,10 +971,10 @@ impl<'a> Match<'a> {
             arms.push(arm);
         }
         if arms.is_empty() {
-            return Err(ErrMode::Cut(ErrorContext::new(
+            return cut_error!(
                 "`match` nodes must contain at least one `when` node and/or an `else` case",
                 start,
-            )));
+            );
         }
 
         Ok(WithSpan::new(
@@ -1079,13 +1061,13 @@ fn check_end_name<'a>(
         return Ok(end_name);
     }
 
-    Err(ErrMode::Cut(ErrorContext::new(
+    cut_error!(
         match name.is_empty() && !end_name.is_empty() {
             true => format!("unexpected name `{end_name}` in `end{kind}` tag for unnamed `{kind}`"),
             false => format!("expected name `{name}` in `end{kind}` tag, found `{end_name}`"),
         },
         before,
-    )))
+    )
 }
 
 #[derive(Debug, PartialEq)]
@@ -1231,20 +1213,20 @@ impl<'a> Let<'a> {
                 }
             };
             if let Some(kind) = kind {
-                return Err(ErrMode::Cut(ErrorContext::new(
+                return cut_error!(
                     format!(
                         "when you forward-define a variable, you cannot use {kind} in place of \
                          a variable name"
                     ),
                     start,
-                )));
+                );
             }
         }
         if is_mut.is_some() && !matches!(var, Target::Name(_)) {
-            return Err(ErrMode::Cut(ErrorContext::new(
+            return cut_error!(
                 "you can only use the `mut` keyword with a variable name",
                 start,
-            )));
+            );
         }
 
         Ok(WithSpan::new(
@@ -1404,7 +1386,7 @@ impl<'a> Comment<'a> {
 
         let mut ws = Ws(None, None);
         if content.len() == 1 && matches!(content, "-" | "+" | "~") {
-            return Err(ErrMode::Cut(ErrorContext::new(
+            return cut_error!(
                 format!(
                     "ambiguous whitespace stripping\n\
                      use `{}{content} {content}{}` to apply the same whitespace stripping on both \
@@ -1412,7 +1394,7 @@ impl<'a> Comment<'a> {
                     s.syntax.comment_start, s.syntax.comment_end,
                 ),
                 start,
-            )));
+            );
         } else if content.len() >= 2 {
             ws.0 = Whitespace::parse_char(content.chars().next().unwrap_or_default());
             ws.1 = Whitespace::parse_char(content.chars().next_back().unwrap_or_default());
@@ -1439,10 +1421,10 @@ fn end_node<'a, 'g: 'a>(
             Ok(actual)
         } else if actual.starts_with("end") {
             i.reset(&start);
-            Err(ErrMode::Cut(ErrorContext::new(
+            cut_error!(
                 format!("expected `{expected}` to terminate `{node}` node, found `{actual}`"),
                 *i,
-            )))
+            )
         } else {
             i.reset(&start);
             fail.parse_next(i)

--- a/askama_parser/src/target.rs
+++ b/askama_parser/src/target.rs
@@ -5,8 +5,8 @@ use winnow::{ModalParser, Parser};
 
 use crate::{
     CharLit, ErrorContext, Num, ParseErr, ParseResult, PathOrIdentifier, State, StrLit, WithSpan,
-    bool_lit, can_be_variable_name, char_lit, identifier, is_rust_keyword, keyword, num_lit,
-    path_or_identifier, str_lit, ws,
+    bool_lit, can_be_variable_name, char_lit, cut_error, identifier, is_rust_keyword, keyword,
+    num_lit, path_or_identifier, str_lit, ws,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -112,18 +112,12 @@ impl<'a> Target<'a> {
             if let [name] = path.as_slice() {
                 // If the path only contains one item, we need to check the name.
                 if !can_be_variable_name(name) {
-                    return Err(ErrMode::Cut(ErrorContext::new(
-                        format!("`{name}` cannot be used as an identifier"),
-                        *name,
-                    )));
+                    return cut_error!(format!("`{name}` cannot be used as an identifier"), *name);
                 }
             } else {
                 // Otherwise we need to check every element but the first.
                 if let Some(name) = path.iter().skip(1).find(|n| !can_be_variable_name(n)) {
-                    return Err(ErrMode::Cut(ErrorContext::new(
-                        format!("`{name}` cannot be used as an identifier"),
-                        *name,
-                    )));
+                    return cut_error!(format!("`{name}` cannot be used as an identifier"), *name);
                 }
             }
 
@@ -163,20 +157,17 @@ impl<'a> Target<'a> {
         if let Some(rest) = rest {
             let chr = peek(ws(opt(one_of([',', ':'])))).parse_next(i)?;
             if let Some(chr) = chr {
-                return Err(ErrMode::Cut(ErrorContext::new(
+                return cut_error!(
                     format!(
                         "unexpected `{chr}` character after `..`\n\
                          note that in a named struct, `..` must come last to ignore other members"
                     ),
                     *i,
-                )));
+                );
             }
             if let Target::Rest(ref s) = rest.0 {
                 if s.inner.is_some() {
-                    return Err(ErrMode::Cut(ErrorContext::new(
-                        "`@ ..` cannot be used in struct",
-                        s.span,
-                    )));
+                    return cut_error!("`@ ..` cannot be used in struct", s.span);
                 }
             }
             return Ok((rest.1, rest.0));
@@ -191,10 +182,7 @@ impl<'a> Target<'a> {
 
         if src == "_" {
             *i = start;
-            return Err(ErrMode::Cut(ErrorContext::new(
-                "cannot use placeholder `_` as source in named struct",
-                *i,
-            )));
+            return cut_error!("cannot use placeholder `_` as source in named struct", *i);
         }
 
         let target = match target {
@@ -216,20 +204,17 @@ impl<'a> Target<'a> {
 
 fn verify_name<'a>(input: &'a str, name: &'a str) -> Result<Target<'a>, ErrMode<ErrorContext<'a>>> {
     if is_rust_keyword(name) {
-        Err(ErrMode::Cut(ErrorContext::new(
+        cut_error!(
             format!("cannot use `{name}` as a name: it is a rust keyword"),
             input,
-        )))
+        )
     } else if !can_be_variable_name(name) {
-        Err(ErrMode::Cut(ErrorContext::new(
-            format!("`{name}` cannot be used as an identifier"),
-            input,
-        )))
+        cut_error!(format!("`{name}` cannot be used as an identifier"), input)
     } else if name.starts_with("__askama") {
-        Err(ErrMode::Cut(ErrorContext::new(
+        cut_error!(
             format!("cannot use `{name}` as a name: it is reserved for `askama`"),
             input,
-        )))
+        )
     } else {
         Ok(Target::Name(name))
     }
@@ -250,10 +235,7 @@ fn collect_targets<'a, T>(
 
     let targets = opt(separated(1.., one, ws(',')).map(|v: Vec<_>| v)).parse_next(i)?;
     let Some(targets) = targets else {
-        return Err(ErrMode::Cut(ErrorContext::new(
-            "expected comma separated list of members",
-            *i,
-        )));
+        return cut_error!("expected comma separated list of members", *i);
     };
 
     let (has_comma, has_end) = (opt_comma, opt_end).parse_next(i)?;
@@ -262,7 +244,7 @@ fn collect_targets<'a, T>(
             true => format!("expected member, or `{delim}` as terminator"),
             false => format!("expected `,` for more members, or `{delim}` as terminator"),
         };
-        return Err(ErrMode::Cut(ErrorContext::new(msg, *i)));
+        return cut_error!(msg, *i);
     }
 
     let singleton = !has_comma && targets.len() == 1;
@@ -279,16 +261,13 @@ fn only_one_rest_pattern<'a>(
     for target in &targets {
         if let Target::Rest(s) = target {
             if !allow_named_rest && s.inner.is_some() {
-                return Err(ErrMode::Cut(ErrorContext::new(
-                    "`@ ..` is only allowed in slice patterns",
-                    s.span,
-                )));
+                return cut_error!("`@ ..` is only allowed in slice patterns", s.span);
             }
             if found_rest {
-                return Err(ErrMode::Cut(ErrorContext::new(
+                return cut_error!(
                     format!("`..` can only be used once per {type_kind} pattern"),
                     s.span,
-                )));
+                );
             }
             found_rest = true;
         }


### PR DESCRIPTION
This change cuts 40 to 150 instructions per parsing function that generates an `ErrorContext`, and reduces the stack usage per function 500 or more bytes.

Also, it's less code you have to read and type per error message.

<details>

<summary>Benchmark results (benches/from_str.rs)</summary>

```text
librustdoc/all          time:   [177.24 µs 177.92 µs 178.56 µs]
                        thrpt:  [79.081 MiB/s 79.369 MiB/s 79.674 MiB/s]
                 change:
                        time:   [−2.3057% −2.0764% −1.8236%] (p = 0.00 < 0.05)
                        thrpt:  [+1.8575% +2.1204% +2.3601%]
                        Performance has improved.

librustdoc/item_info    time:   [3.1792 µs 3.1890 µs 3.1973 µs]
                        thrpt:  [49.216 MiB/s 49.344 MiB/s 49.495 MiB/s]
                 change:
                        time:   [−4.3188% −3.9734% −3.6065%] (p = 0.00 < 0.05)
                        thrpt:  [+3.7414% +4.1378% +4.5137%]
                        Performance has improved.

librustdoc/item_union   time:   [18.237 µs 18.297 µs 18.369 µs]
                        thrpt:  [53.734 MiB/s 53.945 MiB/s 54.123 MiB/s]
                 change:
                        time:   [−3.6142% −3.2857% −2.9748%] (p = 0.00 < 0.05)
                        thrpt:  [+3.0660% +3.3974% +3.7497%]
                        Performance has improved.

librustdoc/page         time:   [83.761 µs 84.102 µs 84.414 µs]
                        thrpt:  [73.355 MiB/s 73.627 MiB/s 73.927 MiB/s]
                 change:
                        time:   [−2.4929% −2.2196% −1.9439%] (p = 0.00 < 0.05)
                        thrpt:  [+1.9825% +2.2700% +2.5566%]
                        Performance has improved.

librustdoc/print_item   time:   [9.5466 µs 9.5528 µs 9.5603 µs]
                        thrpt:  [98.756 MiB/s 98.834 MiB/s 98.898 MiB/s]
                 change:
                        time:   [−1.4294% −1.2085% −0.9713%] (p = 0.00 < 0.05)
                        thrpt:  [+0.9808% +1.2233% +1.4501%]
                        Change within noise threshold.

librustdoc/short_item_info
                        time:   [8.8031 µs 8.8127 µs 8.8204 µs]
                        thrpt:  [102.72 MiB/s 102.80 MiB/s 102.92 MiB/s]
                 change:
                        time:   [−4.3207% −3.9712% −3.6035%] (p = 0.00 < 0.05)
                        thrpt:  [+3.7382% +4.1355% +4.5158%]
                        Performance has improved.

librustdoc/sidebar      time:   [20.181 µs 20.218 µs 20.253 µs]
                        thrpt:  [60.933 MiB/s 61.036 MiB/s 61.150 MiB/s]
                 change:
                        time:   [−2.5827% −2.3381% −2.0839%] (p = 0.00 < 0.05)
                        thrpt:  [+2.1283% +2.3940% +2.6512%]
                        Performance has improved.

librustdoc/source       time:   [7.2338 µs 7.2377 µs 7.2423 µs]
                        thrpt:  [101.79 MiB/s 101.85 MiB/s 101.91 MiB/s]
                 change:
                        time:   [−3.1453% −2.8930% −2.6317%] (p = 0.00 < 0.05)
                        thrpt:  [+2.7028% +2.9792% +3.2475%]
                        Performance has improved.

librustdoc/type_layout_size
                        time:   [4.3755 µs 4.3774 µs 4.3792 µs]
                        thrpt:  [61.847 MiB/s 61.874 MiB/s 61.900 MiB/s]
                 change:
                        time:   [−6.6822% −6.5162% −6.3593%] (p = 0.00 < 0.05)
                        thrpt:  [+6.7912% +6.9704% +7.1607%]
                        Performance has improved.

librustdoc/type_layout  time:   [14.297 µs 14.316 µs 14.331 µs]
                        thrpt:  [187.86 MiB/s 188.06 MiB/s 188.30 MiB/s]
                 change:
                        time:   [−3.2479% −2.8916% −2.6244%] (p = 0.00 < 0.05)
                        thrpt:  [+2.6952% +2.9777% +3.3569%]
                        Performance has improved.
```

</details>