### PR TITLE
Fix #507: Callsite Context is declaration context

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -88,6 +88,11 @@ struct Generator<'a, 'h> {
     seen_callers: Vec<(&'a Call<'a>, &'a Macro<'a>, Option<FileInfo<'a>>)>,
     /// the active caller within the macro.
     active_caller: Option<&'a Call<'a>>,
+    /// This is a callstack to keep track of the context where a call block started.
+    /// This is required, since the {{caller()}} basically calls from the macro's context
+    /// back into the call-site's context.
+    /// For every call-block, we push the current context into this and then pop it after.
+    caller_stack: Vec<Context<'a>>,
 }
 
 impl<'a, 'h> Generator<'a, 'h> {
@@ -114,6 +119,7 @@ impl<'a, 'h> Generator<'a, 'h> {
             is_in_filter_block,
             seen_callers: Vec::new(),
             active_caller: None,
+            caller_stack: vec![contexts[&input.path].clone()],
         }
     }
 

--- a/testing/templates/macro-with-caller.html
+++ b/testing/templates/macro-with-caller.html
@@ -1,0 +1,12 @@
+{%- macro outer() -%}
+    <div>{{caller()}}</div>
+{%- endmacro -%}
+
+{%- macro inner() -%}
+    content
+{%- endmacro -%}
+
+{%- macro intermediate() -%}
+    intermediate
+    {%- call inner() -%}{%- endcall -%}
+{%- endmacro -%}

--- a/testing/tests/macro.rs
+++ b/testing/tests/macro.rs
@@ -75,6 +75,24 @@ fn test_nested_macro_with_args() {
 }
 
 #[test]
+fn test_macro_caller_context_is_declaration_site() {
+    #[derive(Template)]
+    #[template(
+        ext = "html",
+        source = r#"
+{%- import "macro-with-caller.html" as parentscope -%}
+{%- call parentscope::outer() -%}
+    {%- call parentscope::intermediate() -%}{%- endcall -%}
+{%- endcall -%}
+    "#
+    )]
+    struct CallsiteContextIsDeclarationSiteTemplate {}
+
+    let t = CallsiteContextIsDeclarationSiteTemplate {};
+    assert_eq!(t.render().unwrap(), "<div>intermediatecontent</div>");
+}
+
+#[test]
 fn str_cmp() {
     #[derive(Template)]
     #[template(path = "macro-import-str-cmp.html")]


### PR DESCRIPTION
This adds a callstack to the `Generator` that keeps track of call-site contexts, since `{{caller()}}` blocks basically call back into call-site context.