### PR TITLE
using include in call block panics proc-macro

### DIFF
--- a/askama_derive/src/input.rs
+++ b/askama_derive/src/input.rs
@@ -299,10 +299,12 @@ impl TemplateInput<'_> {
                                 nested.push(&arm.nodes);
                             }
                         }
+                        Node::Call(c) => {
+                            nested.push(&c.nodes);
+                        }
                         Node::Lit(_)
                         | Node::Comment(_)
                         | Node::Expr(_, _)
-                        | Node::Call(_)
                         | Node::Extends(_)
                         | Node::Let(_)
                         | Node::Import(_)

--- a/testing/tests/calls.rs
+++ b/testing/tests/calls.rs
@@ -175,6 +175,47 @@ b: {{value.b}}
 }
 
 #[test]
+fn test_include_in_call_block() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
+{%- macro test_macro() -%}
+    {{caller()}}
+{%- endmacro -%}
+{%- call test_macro() %}
+    {%- include "foo.html" -%}
+{%- endcall -%}
+        "#,
+        ext = "txt"
+    )]
+    struct IncludeInCallBlock;
+    let x = IncludeInCallBlock {};
+    assert_eq!(x.render().unwrap(), "foo.html");
+}
+
+#[test]
+fn test_include_in_call_block_in_macro() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
+{%- macro macro1() -%}
+    {{caller()}}
+{%- endmacro -%}
+{%- macro macro2() -%}
+    {%- call macro1() -%}
+        {%- include "foo.html" -%}
+    {%- endcall -%}
+{%- endmacro -%}
+{%- call macro2() %}{%- endcall -%}
+        "#,
+        ext = "txt"
+    )]
+    struct IncludeInCallBlock;
+    let x = IncludeInCallBlock {};
+    assert_eq!(x.render().unwrap(), "foo.html");
+}
+
+#[test]
 fn test_caller_args() {
     #[derive(Template)]
     #[template(

--- a/testing/tests/macro.rs
+++ b/testing/tests/macro.rs
@@ -75,6 +75,23 @@ fn test_nested_macro_with_args() {
 }
 
 #[test]
+fn test_include_in_macro_block() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
+{%- macro test_macro() -%}
+    {%- include "foo.html" -%}
+{%- endmacro -%}
+{%- call test_macro() %}{%- endcall -%}
+        "#,
+        ext = "txt"
+    )]
+    struct IncludeInMacroBlock;
+    let x = IncludeInMacroBlock {};
+    assert_eq!(x.render().unwrap(), "foo.html");
+}
+
+#[test]
 fn str_cmp() {
     #[derive(Template)]
     #[template(path = "macro-import-str-cmp.html")]


### PR DESCRIPTION
The include's context was not available because `find_used_templates` was not scanning for includes inside `call`-blocks.

Fixes #508.