### PR TITLE
Improve askama_derive error output

### DIFF
--- a/askama_derive/src/lib.rs
+++ b/askama_derive/src/lib.rs
@@ -261,8 +261,9 @@ pub fn derive_template(input: TokenStream, import_askama: fn() -> TokenStream) -
                     Error: {err}\n\n\
                     Generated source:\n\
                     ------------------------------------------------\n\
-                    {src}\n\
-                    ------------------------------------------------\n\n"
+                    {}\n\
+                    ------------------------------------------------\n\n",
+                    src.replace('\u{1b}', " "),
                 ),
             }
         })

--- a/askama_derive/src/lib.rs
+++ b/askama_derive/src/lib.rs
@@ -261,7 +261,7 @@ pub fn derive_template(input: TokenStream, import_askama: fn() -> TokenStream) -
                     Error: {err}\n\n\
                     Generated source:\n\
                     ------------------------------------------------\n\
-                    {src:?}\n\
+                    {src}\n\
                     ------------------------------------------------\n\n"
                 ),
             }


### PR DESCRIPTION
Since it's already surrounded with `----`, it makes it much easier to copy/paste the output and just run it.