### PR TITLE
Implement #531: Allow named arguments in call expr macro invocations

### DIFF
--- a/askama_derive/src/generator/expr.rs
+++ b/askama_derive/src/generator/expr.rs
@@ -485,6 +485,14 @@ impl<'a> Generator<'a, '_> {
         left: &WithSpan<'a, Expr<'a>>,
         args: &[WithSpan<'a, Expr<'a>>],
     ) -> Result<DisplayWrap, CompileError> {
+        // ensure that no named args are used in normal rust call expressions
+        if let Some(arg) = args
+            .iter()
+            .find(|&arg| matches!(**arg, Expr::NamedArgument(_, _)))
+        {
+            return Err(ctx.generate_error("Unsupported use of named arguments", arg.span()));
+        }
+
         match &**left {
             Expr::AssociatedItem(sub_left, AssociatedItem { name, generics })
                 if ***sub_left == Expr::Var("loop") =>

--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -885,7 +885,7 @@ impl<'a> Call<'a> {
                 (
                     opt((ws(identifier), ws("::"))),
                     ws(identifier),
-                    opt(ws(|nested: &mut _| Expr::arguments(nested, s.level, true))),
+                    opt(ws(|nested: &mut _| Expr::arguments(nested, s.level))),
                     opt(Whitespace::parse),
                     |i: &mut _| s.tag_block_end(i),
                 ),

--- a/testing/tests/macro.rs
+++ b/testing/tests/macro.rs
@@ -581,6 +581,31 @@ fn test_expr_macro_call_importchain_nested() {
 }
 
 #[test]
+fn test_expr_macro_call_named_arguments() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
+{%- macro testmacro(arg0 = "-", arg1 = 5) -%}
+    {{ arg0 }} | {{ arg1 }};
+{%- endmacro -%}
+{{- testmacro() }}
+{{- testmacro("a") }}
+{{- testmacro("b", 1337) }}
+{{- testmacro("c", arg1 = 1338) }}
+{{- testmacro(arg0 = "d", arg1 = 1339) -}}
+"#,
+        ext = "html"
+    )]
+    struct ExprMacroCall;
+
+    // primarily checking for compilation
+    assert_eq!(
+        ExprMacroCall.render().unwrap(),
+        "- | 5;a | 5;b | 1337;c | 1338;d | 1339;"
+    );
+}
+
+#[test]
 fn test_macro_caller_is_defined_check() {
     #[derive(Template)]
     #[template(

--- a/testing/tests/ui/caller_arguments.rs
+++ b/testing/tests/ui/caller_arguments.rs
@@ -89,20 +89,4 @@ struct CallerInCaller1 {
 struct JustCaller{
 }
 
-#[derive(Template)]
-#[template(
-    source = r#"
-    {% macro test() %}
-        {{ caller("a", one = "b") }}
-    {%- endmacro -%}
-    {%- call(two, one) test() -%}
-        {{- two -}} {{- one -}}
-    {%- endcall -%}
-    "#,
-    ext = "txt"
-)]
-struct NamedArguments {
-}
-
 fn main() {}
-

--- a/testing/tests/ui/caller_arguments.stderr
+++ b/testing/tests/ui/caller_arguments.stderr
@@ -80,18 +80,3 @@ error: block is not defined for `caller`
    |
 86 |     source = r#"{{caller()}}"#,
    |              ^^^^^^^^^^^^^^^^^
-
-error: failed to parse template source
- --> <source attribute>:3:27
-       "= \"b\") }}\n    {%- endmacro -%}\n    {%- call(two, one) test() -%}\n        {{- two"...
-   --> tests/ui/caller_arguments.rs:94:14
-    |
-94  |       source = r#"
-    |  ______________^
-95  | |     {% macro test() %}
-96  | |         {{ caller("a", one = "b") }}
-97  | |     {%- endmacro -%}
-...   |
-100 | |     {%- endcall -%}
-101 | |     "#,
-    | |______^

--- a/testing/tests/ui/expr_fn_calls.rs
+++ b/testing/tests/ui/expr_fn_calls.rs
@@ -1,0 +1,35 @@
+#![allow(unused_variables)]
+
+use askama::Template;
+
+pub fn static_fn(arg: &str) -> &str { arg }
+pub fn static_fn2(arg: &str) -> Option<&str> { Some(arg) }
+
+
+#[derive(Template)]
+#[template(source = "{{ test_fn(arg = 5) }}", ext = "html")]
+struct NamedArgsInRustExprMemberFn;
+
+impl NamedArgsInRustExprMemberFn {
+    pub fn test_fn(&self, arg: u64) -> &'static str {
+        "This is a test"
+    }
+}
+
+
+#[derive(Template)]
+#[template(source = r#"{{ self::static_fn(arg = "test") }}"#, ext = "html")]
+struct NamedArgsInRustExprStaticCall;
+
+
+#[derive(Template)]
+#[template(source = r#"{{ self::static_fn2("test").unwrap(arg = "test") }}"#, ext = "html")]
+struct NamedArgsInRustExprStaticCall2;
+
+
+#[derive(Template)]
+#[template(source = r#"{% let test = self::static_fn(arg = "test") %}"#, ext = "html")]
+struct NamedArgsInRustExprStaticCall3;
+
+
+fn main() {}

--- a/testing/tests/ui/expr_fn_calls.stderr
+++ b/testing/tests/ui/expr_fn_calls.stderr
@@ -1,0 +1,31 @@
+error: failed to parse template source
+ --> <source attribute>:1:15
+       "= 5) }}"
+  --> tests/ui/expr_fn_calls.rs:10:21
+   |
+10 | #[template(source = "{{ test_fn(arg = 5) }}", ext = "html")]
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: failed to parse template source
+ --> <source attribute>:1:23
+       "= \"test\") }}"
+  --> tests/ui/expr_fn_calls.rs:21:21
+   |
+21 | #[template(source = r#"{{ self::static_fn(arg = "test") }}"#, ext = "html")]
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: failed to parse template source
+ --> <source attribute>:1:39
+       "= \"test\") }}"
+  --> tests/ui/expr_fn_calls.rs:26:21
+   |
+26 | #[template(source = r#"{{ self::static_fn2("test").unwrap(arg = "test") }}"#, ext = "html")]
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: failed to parse template source
+ --> <source attribute>:1:34
+       "= \"test\") %}"
+  --> tests/ui/expr_fn_calls.rs:31:21
+   |
+31 | #[template(source = r#"{% let test = self::static_fn(arg = "test") %}"#, ext = "html")]
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testing/tests/ui/expr_fn_calls.stderr
+++ b/testing/tests/ui/expr_fn_calls.stderr
@@ -1,30 +1,30 @@
-error: failed to parse template source
- --> <source attribute>:1:15
-       "= 5) }}"
+error: Unsupported use of named arguments
+ --> NamedArgsInRustExprMemberFn.html:1:10
+       "(arg = 5) }}"
   --> tests/ui/expr_fn_calls.rs:10:21
    |
 10 | #[template(source = "{{ test_fn(arg = 5) }}", ext = "html")]
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: failed to parse template source
- --> <source attribute>:1:23
-       "= \"test\") }}"
+error: Unsupported use of named arguments
+ --> NamedArgsInRustExprStaticCall.html:1:18
+       "(arg = \"test\") }}"
   --> tests/ui/expr_fn_calls.rs:21:21
    |
 21 | #[template(source = r#"{{ self::static_fn(arg = "test") }}"#, ext = "html")]
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: failed to parse template source
- --> <source attribute>:1:39
-       "= \"test\") }}"
+error: Unsupported use of named arguments
+ --> NamedArgsInRustExprStaticCall2.html:1:34
+       "(arg = \"test\") }}"
   --> tests/ui/expr_fn_calls.rs:26:21
    |
 26 | #[template(source = r#"{{ self::static_fn2("test").unwrap(arg = "test") }}"#, ext = "html")]
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: failed to parse template source
- --> <source attribute>:1:34
-       "= \"test\") %}"
+error: Unsupported use of named arguments
+ --> NamedArgsInRustExprStaticCall3.html:1:29
+       "(arg = \"test\") %}"
   --> tests/ui/expr_fn_calls.rs:31:21
    |
 31 | #[template(source = r#"{% let test = self::static_fn(arg = "test") %}"#, ext = "html")]


### PR DESCRIPTION
@Kijewski 's pointer in https://github.com/askama-rs/askama/issues/531#issuecomment-3097969535 was priceless. Thank you!
I thought I would have to add support for named arguments to the lexer of `Expr` first...

Turns out the change is actually quite easy.
**Hint:** It's probably easier to read commit by commit again

Fixes #531.