### PR TITLE
derive: make `EvaluatedResult` know its unknown result

### DIFF
--- a/askama_derive/src/generator/filter.rs
+++ b/askama_derive/src/generator/filter.rs
@@ -760,11 +760,11 @@ impl<'a> Generator<'a, '_> {
         value: &WithSpan<'a, Expr<'a>>,
         fallback: &WithSpan<'a, Expr<'a>>,
     ) -> Result<DisplayWrap, CompileError> {
-        if let Expr::Var(var_name) = **value {
-            if !self.is_var_assigned(var_name) {
-                self.visit_expr(ctx, buf, fallback)?;
-                return Ok(DisplayWrap::Unwrapped);
-            }
+        if let Expr::Var(var_name) = **value
+            && !self.is_var_assigned(var_name)
+        {
+            self.visit_expr(ctx, buf, fallback)?;
+            return Ok(DisplayWrap::Unwrapped);
         }
 
         buf.write("askama::filters::assigned_or(&(");

--- a/askama_derive/src/tests.rs
+++ b/askama_derive/src/tests.rs
@@ -678,7 +678,7 @@ fn check_bool_conditions() {
     // condition.
     compare(
         "{% if y == 3 || (true || x == 12) %}{{x}}{% endif %}",
-        r"if askama::helpers::as_bool(&(self.y == 3)) || (true) {
+        r"if askama::helpers::as_bool(&(self.y == 3)) || true {
     match (
         &((&&askama::filters::AutoEscaper::new(
             &(self.x),


### PR DESCRIPTION
This PR adds a `WithSpan<Expr>` member to `EvaluatedResult::Unknown`, so `Generator::evaluate_condition()` does not have to return a tuple.

Resolves <https://github.com/askama-rs/askama/discussions/535>.

(Can a discussion be resolved? I guess I'll stick with issues again in the future.)