### PR TITLE
parser/derive: replaces usages of `Expr`/`Node` with `Box<Expr>`/`Box<Node>`

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -726,7 +726,7 @@ impl<'a> Deref for WritableBuffer<'a> {
 #[derive(Debug)]
 enum Writable<'a> {
     Lit(Cow<'a, str>),
-    Expr(&'a WithSpan<'a, Expr<'a>>),
+    Expr(&'a WithSpan<'a, Box<Expr<'a>>>),
 }
 
 /// Identifiers to be replaced with raw identifiers, so as to avoid

--- a/askama_derive/src/heritage.rs
+++ b/askama_derive/src/heritage.rs
@@ -43,7 +43,7 @@ type BlockAncestry<'a, 'h> =
 
 #[derive(Clone)]
 pub(crate) struct Context<'a> {
-    pub(crate) nodes: &'a [Node<'a>],
+    pub(crate) nodes: &'a [Box<Node<'a>>],
     pub(crate) extends: Option<Arc<Path>>,
     pub(crate) blocks: HashMap<&'a str, &'a BlockDef<'a>, FxBuildHasher>,
     pub(crate) macros: HashMap<&'a str, &'a Macro<'a>, FxBuildHasher>,
@@ -82,7 +82,7 @@ impl<'a> Context<'a> {
 
         while let Some(nodes) = nested.pop() {
             for n in nodes {
-                match n {
+                match &**n {
                     Node::Extends(e) => {
                         ensure_top(top, e.span(), path, parsed, "extends")?;
                         if extends.is_some() {

--- a/askama_derive/src/input.rs
+++ b/askama_derive/src/input.rs
@@ -222,7 +222,7 @@ impl TemplateInput<'_> {
                         Ok(())
                     };
 
-                    match n {
+                    match &**n {
                         Node::Extends(extends) if top => {
                             #[cfg(not(feature = "external-sources"))]
                             {


### PR DESCRIPTION
This means that there is much less copying of data done at runtime.

Two new `unsafe` transmutations had to be added, both in the same function, because even though `&T` and `Box<T>` have the same layout, rust currently rejects any `Box`es in a `const` value. Miri is happy with `askama_derive`'s tests.

<details>
<summary>askama_derive benchmark</summary>

```text
synthetic/hello_world   time:   [35.108 µs 35.271 µs 35.412 µs]
                        thrpt:  [1.3735 MiB/s 1.3790 MiB/s 1.3854 MiB/s]
                 change:
                        time:   [−6.2826% −5.1769% −4.1151%] (p = 0.00 < 0.05)
                        thrpt:  [+4.2917% +5.4595% +6.7038%]
                        Performance has improved.

librustdoc/item_info.html
                        time:   [39.687 µs 39.957 µs 40.186 µs]
                        thrpt:  [3.9157 MiB/s 3.9381 MiB/s 3.9649 MiB/s]
                 change:
                        time:   [−3.5603% −2.5102% −1.3793%] (p = 0.00 < 0.05)
                        thrpt:  [+1.3986% +2.5749% +3.6917%]
                        Performance has improved.

librustdoc/item_union.html
                        time:   [101.64 µs 101.95 µs 102.27 µs]
                        thrpt:  [9.6516 MiB/s 9.6818 MiB/s 9.7111 MiB/s]
                 change:
                        time:   [−4.0638% −3.5966% −3.1652%] (p = 0.00 < 0.05)
                        thrpt:  [+3.2686% +3.7307% +4.2359%]
                        Performance has improved.

librustdoc/page.html    time:   [379.80 µs 381.74 µs 383.65 µs]
                        thrpt:  [16.140 MiB/s 16.221 MiB/s 16.304 MiB/s]
                 change:
                        time:   [−6.6429% −5.2611% −4.3384%] (p = 0.00 < 0.05)
                        thrpt:  [+4.5351% +5.5533% +7.1156%]
                        Performance has improved.

librustdoc/print_item.html
                        time:   [88.483 µs 88.849 µs 89.313 µs]
                        thrpt:  [10.571 MiB/s 10.626 MiB/s 10.670 MiB/s]
                 change:
                        time:   [−2.5658% −2.0639% −1.5517%] (p = 0.00 < 0.05)
                        thrpt:  [+1.5761% +2.1074% +2.6333%]
                        Performance has improved.

librustdoc/short_item_info.html
                        time:   [90.028 µs 90.157 µs 90.281 µs]
                        thrpt:  [10.035 MiB/s 10.049 MiB/s 10.063 MiB/s]
                 change:
                        time:   [−2.4814% −1.9435% −1.3640%] (p = 0.00 < 0.05)
                        thrpt:  [+1.3829% +1.9821% +2.5445%]
                        Performance has improved.

librustdoc/sidebar.html time:   [106.91 µs 108.17 µs 109.57 µs]
                        thrpt:  [11.263 MiB/s 11.408 MiB/s 11.543 MiB/s]
                 change:
                        time:   [−4.2433% −3.3985% −2.6066%] (p = 0.00 < 0.05)
                        thrpt:  [+2.6763% +3.5181% +4.4314%]
                        Performance has improved.

librustdoc/source.html  time:   [71.149 µs 71.416 µs 71.652 µs]
                        thrpt:  [10.289 MiB/s 10.322 MiB/s 10.361 MiB/s]
                 change:
                        time:   [−2.7381% −2.1144% −1.5588%] (p = 0.00 < 0.05)
                        thrpt:  [+1.5835% +2.1601% +2.8152%]
                        Performance has improved.

librustdoc/type_layout.html
                        time:   [88.405 µs 88.920 µs 89.595 µs]
                        thrpt:  [30.049 MiB/s 30.277 MiB/s 30.453 MiB/s]
                 change:
                        time:   [+0.6665% +1.8855% +3.0267%] (p = 0.00 < 0.05)
                        thrpt:  [−2.9378% −1.8506% −0.6621%]
                        Change within noise threshold.

librustdoc/type_layout_size.html
                        time:   [44.048 µs 44.246 µs 44.398 µs]
                        thrpt:  [6.1004 MiB/s 6.1213 MiB/s 6.1488 MiB/s]
                 change:
                        time:   [−5.8376% −4.9477% −4.0335%] (p = 0.00 < 0.05)
                        thrpt:  [+4.2030% +5.2052% +6.1996%]
                        Performance has improved.
```
</details>