### PR TITLE
derive: track included files with relative path

### DIFF
--- a/askama_derive/src/generator/helpers/mod.rs
+++ b/askama_derive/src/generator/helpers/mod.rs
@@ -1,3 +1,5 @@
 mod macro_invocation;
+mod paths;
 
-pub(crate) use macro_invocation::*;
+pub(crate) use macro_invocation::MacroInvocation;
+pub(crate) use paths::{clean as clean_path, diff_paths};

--- a/askama_derive/src/generator/helpers/paths.rs
+++ b/askama_derive/src/generator/helpers/paths.rs
@@ -23,12 +23,9 @@ use std::path::{Component, Path, PathBuf};
 /// 5. Leave intact `..` elements that begin a non-rooted path.
 ///
 /// If the result of this process is an empty string, return the string `"."`, representing the current directory.
-pub(crate) fn clean<P>(path: P) -> PathBuf
-where
-    P: AsRef<Path>,
-{
+pub(crate) fn clean(path: &Path) -> PathBuf {
     let mut out = Vec::new();
-    for comp in path.as_ref().components() {
+    for comp in path.components() {
         match comp {
             Component::CurDir => (),
             Component::ParentDir => match out.last() {
@@ -52,38 +49,7 @@ where
 }
 
 /// Construct a relative path from a provided base directory path to the provided path.
-///
-/// ```rust
-/// use pathdiff::diff_paths;
-/// use std::path::*;
-///
-/// assert_eq!(diff_paths("/foo/bar",      "/foo/bar/baz"),  Some("../".into()));
-/// assert_eq!(diff_paths("/foo/bar/baz",  "/foo/bar"),      Some("baz".into()));
-/// assert_eq!(diff_paths("/foo/bar/quux", "/foo/bar/baz"),  Some("../quux".into()));
-/// assert_eq!(diff_paths("/foo/bar/baz",  "/foo/bar/quux"), Some("../baz".into()));
-/// assert_eq!(diff_paths("/foo/bar",      "/foo/bar/quux"), Some("../".into()));
-///
-/// assert_eq!(diff_paths("/foo/bar",      "baz"),           Some("/foo/bar".into()));
-/// assert_eq!(diff_paths("/foo/bar",      "/baz"),          Some("../foo/bar".into()));
-/// assert_eq!(diff_paths("foo",           "bar"),           Some("../foo".into()));
-///
-/// assert_eq!(
-///     diff_paths(&"/foo/bar/baz", "/foo/bar".to_string()),
-///     Some("baz".into())
-/// );
-/// assert_eq!(
-///     diff_paths(Path::new("/foo/bar/baz"), Path::new("/foo/bar").to_path_buf()),
-///     Some("baz".into())
-/// );
-/// ```
-pub(crate) fn diff_paths<P, B>(path: P, base: B) -> Option<PathBuf>
-where
-    P: AsRef<Path>,
-    B: AsRef<Path>,
-{
-    let path = path.as_ref();
-    let base = base.as_ref();
-
+pub(crate) fn diff_paths(path: &Path, base: &Path) -> Option<PathBuf> {
     if path.is_absolute() != base.is_absolute() {
         if path.is_absolute() {
             Some(PathBuf::from(path))
@@ -104,8 +70,8 @@ where
                 }
                 (None, _) => comps.push(Component::ParentDir),
                 (Some(a), Some(b)) if comps.is_empty() && a == b => (),
-                (Some(a), Some(b)) if b == Component::CurDir => comps.push(a),
-                (Some(_), Some(b)) if b == Component::ParentDir => return None,
+                (Some(a), Some(Component::CurDir)) => comps.push(a),
+                (Some(_), Some(Component::ParentDir)) => return None,
                 (Some(a), Some(_)) => {
                     comps.push(Component::ParentDir);
                     for _ in itb {
@@ -119,4 +85,41 @@ where
         }
         Some(comps.iter().map(|c| c.as_os_str()).collect())
     }
+}
+
+#[test]
+fn test_diff_paths() {
+    assert_eq!(
+        diff_paths(Path::new("/foo/bar"), Path::new("/foo/bar/baz")),
+        Some("../".into())
+    );
+    assert_eq!(
+        diff_paths(Path::new("/foo/bar/baz"), Path::new("/foo/bar")),
+        Some("baz".into())
+    );
+    assert_eq!(
+        diff_paths(Path::new("/foo/bar/quux"), Path::new("/foo/bar/baz")),
+        Some("../quux".into())
+    );
+    assert_eq!(
+        diff_paths(Path::new("/foo/bar/baz"), Path::new("/foo/bar/quux")),
+        Some("../baz".into())
+    );
+    assert_eq!(
+        diff_paths(Path::new("/foo/bar"), Path::new("/foo/bar/quux")),
+        Some("../".into())
+    );
+
+    assert_eq!(
+        diff_paths(Path::new("/foo/bar"), Path::new("baz")),
+        Some("/foo/bar".into())
+    );
+    assert_eq!(
+        diff_paths(Path::new("/foo/bar"), Path::new("/baz")),
+        Some("../foo/bar".into())
+    );
+    assert_eq!(
+        diff_paths(Path::new("foo"), Path::new("bar")),
+        Some("../foo".into())
+    );
 }

--- a/askama_derive/src/generator/helpers/paths.rs
+++ b/askama_derive/src/generator/helpers/paths.rs
@@ -1,0 +1,122 @@
+use std::path::{Component, Path, PathBuf};
+
+// The function [`clean()`] was copied from the project [`path_clean`] in version 1.0.1 (rev. [`d8948ae`]).
+// License: MIT OR Apache-2.0.
+// Authors: Dan Reeves <hey@danreev.es>, Alex Guerra <alex@heyimalex.com>, Adam Reichold
+//
+// The function [`diff_paths()`] was copied in from the project [`pathdiff`] in version 0.2.3 (rev. [`5180ff5`]).
+// License: MIT OR Apache-2.0.
+// Copyright 2012-2015 The Rust Project Developers.
+//
+// Please see their commit history for more information.
+//
+// [`path_clean`]: <https://github.com/danreeves/path-clean>
+// [`pathdiff`]: <https://github.com/Manishearth/pathdiff>
+// [`d8948ae`]: <https://github.com/danreeves/path-clean/blob/d8948ae69d349ec33dfe6d6b9c6a0fe30288a117/src/lib.rs#L50-L86>
+// [`5180ff5`]: <https://github.com/Manishearth/pathdiff/blob/5180ff5b23d9d7eef0a14de13a3d814eb5d8d65c/src/lib.rs#L18-L86>
+
+/// The core implementation. It performs the following, lexically:
+/// 1. Reduce multiple slashes to a single slash.
+/// 2. Eliminate `.` path name elements (the current directory).
+/// 3. Eliminate `..` path name elements (the parent directory) and the non-`.` non-`..`, element that precedes them.
+/// 4. Eliminate `..` elements that begin a rooted path, that is, replace `/..` by `/` at the beginning of a path.
+/// 5. Leave intact `..` elements that begin a non-rooted path.
+///
+/// If the result of this process is an empty string, return the string `"."`, representing the current directory.
+pub(crate) fn clean<P>(path: P) -> PathBuf
+where
+    P: AsRef<Path>,
+{
+    let mut out = Vec::new();
+    for comp in path.as_ref().components() {
+        match comp {
+            Component::CurDir => (),
+            Component::ParentDir => match out.last() {
+                Some(Component::RootDir) => (),
+                Some(Component::Normal(_)) => {
+                    out.pop();
+                }
+                None
+                | Some(Component::CurDir)
+                | Some(Component::ParentDir)
+                | Some(Component::Prefix(_)) => out.push(comp),
+            },
+            comp => out.push(comp),
+        }
+    }
+    if !out.is_empty() {
+        out.iter().collect()
+    } else {
+        PathBuf::from(".")
+    }
+}
+
+/// Construct a relative path from a provided base directory path to the provided path.
+///
+/// ```rust
+/// use pathdiff::diff_paths;
+/// use std::path::*;
+///
+/// assert_eq!(diff_paths("/foo/bar",      "/foo/bar/baz"),  Some("../".into()));
+/// assert_eq!(diff_paths("/foo/bar/baz",  "/foo/bar"),      Some("baz".into()));
+/// assert_eq!(diff_paths("/foo/bar/quux", "/foo/bar/baz"),  Some("../quux".into()));
+/// assert_eq!(diff_paths("/foo/bar/baz",  "/foo/bar/quux"), Some("../baz".into()));
+/// assert_eq!(diff_paths("/foo/bar",      "/foo/bar/quux"), Some("../".into()));
+///
+/// assert_eq!(diff_paths("/foo/bar",      "baz"),           Some("/foo/bar".into()));
+/// assert_eq!(diff_paths("/foo/bar",      "/baz"),          Some("../foo/bar".into()));
+/// assert_eq!(diff_paths("foo",           "bar"),           Some("../foo".into()));
+///
+/// assert_eq!(
+///     diff_paths(&"/foo/bar/baz", "/foo/bar".to_string()),
+///     Some("baz".into())
+/// );
+/// assert_eq!(
+///     diff_paths(Path::new("/foo/bar/baz"), Path::new("/foo/bar").to_path_buf()),
+///     Some("baz".into())
+/// );
+/// ```
+pub(crate) fn diff_paths<P, B>(path: P, base: B) -> Option<PathBuf>
+where
+    P: AsRef<Path>,
+    B: AsRef<Path>,
+{
+    let path = path.as_ref();
+    let base = base.as_ref();
+
+    if path.is_absolute() != base.is_absolute() {
+        if path.is_absolute() {
+            Some(PathBuf::from(path))
+        } else {
+            None
+        }
+    } else {
+        let mut ita = path.components();
+        let mut itb = base.components();
+        let mut comps = vec![];
+        loop {
+            match (ita.next(), itb.next()) {
+                (None, None) => break,
+                (Some(a), None) => {
+                    comps.push(a);
+                    comps.extend(ita.by_ref());
+                    break;
+                }
+                (None, _) => comps.push(Component::ParentDir),
+                (Some(a), Some(b)) if comps.is_empty() && a == b => (),
+                (Some(a), Some(b)) if b == Component::CurDir => comps.push(a),
+                (Some(_), Some(b)) if b == Component::ParentDir => return None,
+                (Some(a), Some(_)) => {
+                    comps.push(Component::ParentDir);
+                    for _ in itb {
+                        comps.push(Component::ParentDir);
+                    }
+                    comps.push(a);
+                    comps.extend(ita.by_ref());
+                    break;
+                }
+            }
+        }
+        Some(comps.iter().map(|c| c.as_os_str()).collect())
+    }
+}

--- a/askama_derive/src/lib.rs
+++ b/askama_derive/src/lib.rs
@@ -2,6 +2,8 @@
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unreachable_pub)]
 
+extern crate proc_macro;
+
 mod config;
 mod generator;
 mod heritage;
@@ -14,8 +16,6 @@ mod tests;
 #[doc(hidden)]
 #[cfg(feature = "proc-macro")]
 pub mod __macro_support {
-    extern crate proc_macro;
-
     pub use proc_macro::TokenStream as TokenStream1;
     pub use proc_macro2::TokenStream as TokenStream2;
     pub use quote::quote;


### PR DESCRIPTION
To make the compiler understand which files contributed to the generated code, in order to make it aware when a recompilation is needed, we track the file paths using `include_bytes!()` calls in the generated code. This can be a problem for reproducible builds, because the working directory contributes to the file hash.

This PR makes Askama generate relative paths if possible. This is always possible on Unix systems, but on Windows hosts absolute paths have to be used if the code is kept on different drives.

[`Span::local_file()`](https://doc.rust-lang.org/1.88.0/proc_macro/struct.Span.html#method.local_file) is only stable since rust 1.88, but that's our MSRV for the next release, anyway.

Open questions:
- <del>[ ] Should this behavior be feature gated?</del>
- [x] [`path_clean::clean()`](https://docs.rs/path-clean/1.0.1/src/path_clean/lib.rs.html#58-86) and [`pathdiff:diff_paths()`](https://docs.rs/pathdiff/0.2.3/src/pathdiff/lib.rs.html#43-86) are tiny, and both MIT OR Apache-2.0 licensed. Should we simply copy the code (mentioning the authors, of course)?

Resolves <https://github.com/askama-rs/askama/issues/461>.  
Cc @frankdavid.