### PR TITLE
book: first install mdbook, then use it

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,11 +11,11 @@ build:
     - asdf install rust 1.88.0
     - asdf global rust 1.88.0
 
-    # Generate "book/theme/index.hbs" as "skeleton" of the generated pages.
-    - book/update-theme.py
     # Install mdbook.
     - mkdir -p $HOME/bin
     - curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-quickinstall/releases/download/mdbook-0.4.52/mdbook-0.4.52-x86_64-unknown-linux-gnu.tar.gz | tar -xzvvf - -C $HOME/bin
+    # Generate "book/theme/index.hbs" as "skeleton" of the generated pages.
+    - PATH="$HOME/bin:$PATH" book/update-theme.py
     # Convert the book to HTML.
     - $HOME/bin/mdbook build book --dest-dir $READTHEDOCS_OUTPUT/html
     # Make the ads readable.


### PR DESCRIPTION
This is follow up to [#544], which makes `update-theme.py` use `mdbook` itself to build `index.hbs`. `mdbook` needs to be installed to be used, though.

[#544]: <https://redirect.github.com/askama-rs/askama/pull/544>