### PR TITLE
Do not use `cargo-quickinstall` for now

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,14 +70,12 @@ jobs:
         with:
           persist-credentials: false
       - name: Install mdbook
-        run: |
-          mkdir -p $HOME/bin
-          curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-quickinstall/releases/download/mdbook-0.4.52/mdbook-0.4.52-x86_64-unknown-linux-gnu.tar.gz | tar -xzvvf - -C $HOME/bin
+        run: cargo install mdbook
       - name: Generate "book/theme/index.hbs" as "skeleton" of the generated pages.
-        run: PATH="$HOME/bin:$PATH" ./update-theme.py
+        run: PATH="$HOME/.cargo/bin:$PATH" ./update-theme.py
         working-directory: book
       - name: Convert the book to HTML
-        run: $HOME/bin/mdbook build
+        run: $HOME/.cargo/bin/mdbook build
         working-directory: book
 
   Typos:
@@ -248,7 +246,7 @@ jobs:
         with:
           toolchain: nightly
           components: rust-src
-      - run: curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-quickinstall/releases/download/cargo-fuzz-0.13.1/cargo-fuzz-0.13.1-x86_64-unknown-linux-gnu.tar.gz | tar -xzvvf - -C $HOME/.cargo/bin
+      - run: cargo install cargo-fuzz
       - uses: Swatinem/rust-cache@v2
       - run: cargo fuzz run ${{ matrix.fuzz_target }} --jobs 4 -- -max_total_time=600
         working-directory: fuzzing

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,12 +12,11 @@ build:
     - asdf global rust 1.88.0
 
     # Install mdbook.
-    - mkdir -p $HOME/bin
-    - curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-quickinstall/releases/download/mdbook-0.4.52/mdbook-0.4.52-x86_64-unknown-linux-gnu.tar.gz | tar -xzvvf - -C $HOME/bin
+    - cargo install mdbook
     # Generate "book/theme/index.hbs" as "skeleton" of the generated pages.
-    - PATH="$HOME/bin:$PATH" book/update-theme.py
+    - PATH=".cargo/bin:$PATH" book/update-theme.py
     # Convert the book to HTML.
-    - $HOME/bin/mdbook build book --dest-dir $READTHEDOCS_OUTPUT/html
+    - $HOME/.cargo/bin/mdbook build book --dest-dir $READTHEDOCS_OUTPUT/html
     # Make the ads readable.
     - cat book/ethicalads-theme.css >> $READTHEDOCS_OUTPUT/html/css/general.css
     # We are done!


### PR DESCRIPTION
It seems like cargo-quickinstall had a breach of some sort: [cargo-quickinstall#441]. As a precautionary measure they wiped many pre-compiled files. Amongst them mdbook v0.4.52, which we use to build our book, and cargo-fuzz v0.13.1, which we use for fuzzing.

This PR makes us not use pre-compiled programs, but use `cargo install` instead.

[cargo-quickinstall#441]: <https://redirect.github.com/cargo-bins/cargo-quickinstall/issues/441>