### PR TITLE
Fix mdbook path in readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,9 +14,9 @@ build:
     # Install mdbook.
     - cargo install mdbook
     # Generate "book/theme/index.hbs" as "skeleton" of the generated pages.
-    - PATH=".cargo/bin:$PATH" book/update-theme.py
+    - book/update-theme.py
     # Convert the book to HTML.
-    - $HOME/.cargo/bin/mdbook build book --dest-dir $READTHEDOCS_OUTPUT/html
+    - mdbook build book --dest-dir $READTHEDOCS_OUTPUT/html
     # Make the ads readable.
     - cat book/ethicalads-theme.css >> $READTHEDOCS_OUTPUT/html/css/general.css
     # We are done!


### PR DESCRIPTION
On readthedocs, which uses `asdf` instead of `rustup`, the path for `cargo install` installations is `$HOME/.asdf/installs/rust/1.88.0/bin/XYZ` instead of `$HOME/.cargo.bin`.

It looks like the path this is already in scope, otherwise `book/update-theme.py` would have failed in <https://app.readthedocs.org/projects/askama/builds/29407005/>, too.

(Feel free to skip the CI check.)