### PR TITLE
Add installation instructions for `askama_web`

### DIFF
--- a/book/src/frameworks.md
+++ b/book/src/frameworks.md
@@ -34,6 +34,14 @@ If you don't need custom / stylized error messages,
 e.g. because you know that your templates won't have rendering errors, then using
 [`askama_web`](https://crates.io/crates/askama_web/) might work for you, too.
 
+Install it by adding this to the `Cargo.toml` ; replace `"actix-web-4"` by the feature corresponding to your framework (check [the available feature](https://docs.rs/crate/askama_web/latest/features))
+
+```toml
+[dependencies]
+askama = "0.16"
+askama_web = { version = "0.16", features = ["actix-web-4"] }
+```
+
 ## Actix-Web
 
 [![our actix-web example web-app](


### PR DESCRIPTION
I had some difficulties to setup `askama_web`

As a normal user, i barely read documentation, and rarely click on every link

So, i just added this to my `Cargo.toml`

```toml
[dependencies]
askama = "0.16.0"
askama_web = "0.16.0"
```

It didn't work with Actix, i didn't really understood the error message when trying to compile

Now, it is obvious why it didn't worked

A friend of mine did the exact same things few days latter

So we are at least two that could have an easier setup with the proposed lines