### PR TITLE
Don't canonicalize the tracked config file path

### DIFF
--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -387,7 +387,14 @@ pub(crate) fn read_config_file(
     config_path: Option<&str>,
     span: Option<Span>,
 ) -> Result<(String, Option<PathBuf>), CompileError> {
-    let root = manifest_root();
+    read_config_file_from_root(&manifest_root(), config_path, span)
+}
+
+fn read_config_file_from_root(
+    root: &Path,
+    config_path: Option<&str>,
+    span: Option<Span>,
+) -> Result<(String, Option<PathBuf>), CompileError> {
     let filename = match config_path {
         Some(config_path) => root.join(config_path),
         None => root.join(CONFIG_FILE_NAME),
@@ -400,7 +407,10 @@ pub(crate) fn read_config_file(
                 span,
             )
         })?;
-        Ok((content, filename.canonicalize().ok()))
+        // Like in `Config::find_template()`, don't use `Path::canonicalize()`: the path is
+        // lexically diffed against the unresolved caller path in `Generator::rel_path()`,
+        // so resolving symlinks here would produce a broken path in `include_bytes!()`.
+        Ok((content, absolute(&filename).ok()))
     } else if config_path.is_some() {
         Err(CompileError::no_file_info(
             format_args!("`{}` does not exist", filename.display()),
@@ -443,6 +453,29 @@ mod tests {
         root.push("templates");
         let config = Config::new("", None, None, None, None).unwrap();
         assert_eq!(config.dirs, vec![root]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_read_config_file_keeps_symlinks_unresolved() {
+        // E.g. under a symlinked `CARGO_HOME` the caller path uses the symlinked spelling,
+        // so the tracked config path must keep that spelling, too.
+        let tmp =
+            env::temp_dir().join(format!("askama-config-symlink-test-{}", std::process::id()));
+        let real = tmp.join("real");
+        let link = tmp.join("link");
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&real).unwrap();
+        fs::write(real.join(CONFIG_FILE_NAME), "").unwrap();
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let (_, config_path) = read_config_file_from_root(&link, None, None).unwrap();
+        assert_eq!(
+            config_path,
+            Some(absolute(link.join(CONFIG_FILE_NAME)).unwrap())
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
     }
 
     #[cfg(feature = "config")]

--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -458,22 +458,47 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn test_read_config_file_keeps_symlinks_unresolved() {
-        // E.g. under a symlinked `CARGO_HOME` the caller path uses the symlinked spelling,
-        // so the tracked config path must keep that spelling, too.
-        let tmp =
-            env::temp_dir().join(format!("askama-config-symlink-test-{}", std::process::id()));
-        let real = tmp.join("real");
-        let link = tmp.join("link");
+        use crate::generator::diff_paths;
+
+        // Simulates building a crate through a symlinked path, e.g. a registry cache under
+        // a symlinked `CARGO_HOME`: the caller path (`Span::local_file()`) uses the symlink
+        // spelling, while the symlink's target lives at a different depth:
+        //
+        //   <tmp>/real/deep/proj/askama.toml   actual file
+        //   <tmp>/proj -> <tmp>/real/deep/proj crate root as the compiler sees it
+        //   <tmp>/proj/src                     caller dir
+        //
+        // `env::temp_dir()` is canonicalized so that the only symlink in play is ours.
+        let tmp = env::temp_dir()
+            .canonicalize()
+            .unwrap()
+            .join(format!("askama-config-symlink-test-{}", std::process::id()));
+        let real = tmp.join("real").join("deep").join("proj");
+        let link = tmp.join("proj");
         let _ = fs::remove_dir_all(&tmp);
-        fs::create_dir_all(&real).unwrap();
+        fs::create_dir_all(real.join("src")).unwrap();
         fs::write(real.join(CONFIG_FILE_NAME), "").unwrap();
         std::os::unix::fs::symlink(&real, &link).unwrap();
+        let caller_dir = link.join("src");
+        let manifest_dir = Some(link.display().to_string());
 
+        // The tracked config path must keep the symlink spelling of the manifest root...
         let (_, config_path) = read_config_file_from_root(&link, None, None).unwrap();
-        assert_eq!(
-            config_path,
-            Some(absolute(link.join(CONFIG_FILE_NAME)).unwrap())
-        );
+        let config_path = config_path.unwrap();
+        assert_eq!(config_path, absolute(link.join(CONFIG_FILE_NAME)).unwrap());
+
+        // ...so that the relative path `Generator::rel_path()` computes for `include_bytes!()`
+        // resolves from the caller dir: `diff_paths()` diffs lexically, but the compiler
+        // resolves the `..` components through the symlink.
+        let rel = diff_paths(&config_path, &caller_dir, manifest_dir.clone()).unwrap();
+        assert_eq!(rel, Path::new("..").join(CONFIG_FILE_NAME));
+        fs::metadata(caller_dir.join(rel)).unwrap();
+
+        // The canonicalized spelling that was tracked before diffs into a `..` chain that
+        // escapes through the symlink and points at a file that does not exist.
+        let old_config_path = link.join(CONFIG_FILE_NAME).canonicalize().unwrap();
+        let old_rel = diff_paths(&old_config_path, &caller_dir, manifest_dir).unwrap();
+        fs::metadata(caller_dir.join(old_rel)).unwrap_err();
 
         let _ = fs::remove_dir_all(&tmp);
     }

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -15,7 +15,8 @@ use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, quote_spanned};
 use syn::Token;
 
-use crate::generator::helpers::{clean_path, diff_paths};
+use crate::generator::helpers::clean_path;
+pub(crate) use crate::generator::helpers::diff_paths;
 use crate::heritage::{Context, Heritage};
 use crate::html::write_escaped_str;
 use crate::input::{Source, TemplateInput};

--- a/askama_derive/src/tests.rs
+++ b/askama_derive/src/tests.rs
@@ -1169,10 +1169,7 @@ fn test_with_config() {
         &format!(
             "const _: &[askama::helpers::core::primitive::u8] = \
             askama::helpers::core::include_bytes!({:#?});",
-            Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("empty_test_config.toml")
-                .canonicalize()
-                .unwrap(),
+            absolute(Path::new(env!("CARGO_MANIFEST_DIR")).join("empty_test_config.toml")).unwrap(),
         ),
         &[],
         0,


### PR DESCRIPTION
`read_config_file()` canonicalized the `askama.toml` path before it is lexically diffed against the unresolved caller path in `Generator::rel_path()` and emitted into `include_bytes!()`. When the spellings differ — e.g. building from a registry cache under a symlinked `CARGO_HOME` (dotfiles setups, Fedora Silverblue) — the computed `..` chain escapes through the symlink and the build fails with "couldn't read .../askama.toml".

Same problem #720 fixed for template paths; the config file path was missed. Apply the same `canonicalize()` → `std::path::absolute()` fix.

Note: this was done with the help of Claude Fable, but I reviewed all of it myself.