### PR TITLE
Upgrade to syn 3

### DIFF
--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -34,12 +34,12 @@ memchr = "2"
 proc-macro2 = { version = "1", default-features = false }
 quote = { version = "1", default-features = false }
 rustc-hash = "2.0.0"
-syn = { version = "2.0.3", default-features = false, features = ["clone-impls", "derive", "full", "parsing", "printing"] }
+syn = { version = "3.0.0", default-features = false, features = ["clone-impls", "derive", "full", "parsing", "printing"] }
 
 [dev-dependencies]
 console = "0.16.0"
 criterion = "0.8"
-prettyplease = "0.2.20"
+prettyplease = "0.3.0"
 rand = "0.10.0"
 rand_xoshiro = "0.8.0"
 similar = "2.6.0"

--- a/askama_derive/src/filter_fn.rs
+++ b/askama_derive/src/filter_fn.rs
@@ -164,7 +164,9 @@ impl FilterSignature {
         // generics
         let mut generics = HashMap::default();
         for gp in sig.generics.type_params() {
-            p_assert!(gp.default.is_none(), gp.default.span() => "Filter functions don't support generic parameter defaults")?;
+            if let Some((_, default)) = &gp.default {
+                p_err!(default.span() => "Filter functions don't support generic parameter defaults")?;
+            }
 
             let ident = gp.ident.clone();
             let bounds = gp.bounds.clone();

--- a/fuzzing/fuzz/Cargo.toml
+++ b/fuzzing/fuzz/Cargo.toml
@@ -20,10 +20,10 @@ askama_derive = { path = "../../askama_derive", default-features = false, featur
 arbitrary = { version = "1.3.2", features = ["derive"] }
 html-escape = "0.2.13"
 libfuzzer-sys = "0.4.7"
-prettyplease = "0.2.32"
+prettyplease = "0.3.0"
 proc-macro2 = { version = "1.0.95", default-features = false }
 quote = { version = "1.0.40", default-features = false }
-syn = { version = "2.0.101", default-features = false, features = ["full"] }
+syn = { version = "3.0.0", default-features = false, features = ["full"] }
 thiserror = "2.0.3"
 unicode-ident = "=1.0.18"
 


### PR DESCRIPTION
Bumped dependencies:
- syn 2 -> 3: https://github.com/dtolnay/syn/releases/tag/3.0.0
- prettyplease 0.2 -> 0.3: https://github.com/dtolnay/prettyplease/releases/tag/0.3.0

In syn 3, `TypeParam::default` changed from `Option<Type>` to `Option<(Eq, Type)>`, which no longer implements `Spanned`, so the generic-parameter-default rejection in `filter_fn` now destructures it to get the span.