### PR TITLE
Make template include paths independent of the checkout location

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -178,6 +178,16 @@ impl<'a, 'h> Generator<'a, 'h> {
         if proc_macro::is_available()
             && let Some(mut local_file) = proc_macro::Span::call_site().local_file()
         {
+            // Resolve the calling source file, then take its directory. `rel_path()` diffs
+            // template paths against this, and `Config::find_template()` always canonicalizes
+            // those, so this side has to be canonicalized too or the two are rooted in
+            // different trees -- which makes `diff_paths()` fall back to the absolute path.
+            //
+            // This matters for build systems that stage sources as symlinks into a separate
+            // build tree (Bazel, Buck). There the file is a symlink to the real checkout while
+            // the directory holding it is real, so the symlink that has to be followed is the
+            // file; resolving the directory afterwards would be a no-op.
+            let mut local_file = local_file.canonicalize().unwrap_or(local_file);
             local_file.pop();
             if !local_file.is_absolute() {
                 local_file = Path::new(".").join(local_file);

--- a/askama_derive/src/generator/helpers/paths.rs
+++ b/askama_derive/src/generator/helpers/paths.rs
@@ -65,6 +65,14 @@ pub(crate) fn diff_paths(
     } else {
         if base_is_absolute &&
             let Some(manifest_dir) = manifest_dir &&
+            // Resolve before comparing: `base` is canonical, so a `CARGO_MANIFEST_DIR` that is
+            // relative, or that reaches the crate through a symlink, would never match it
+            // textually even when it names the very same directory. Build systems that stage
+            // sources into a separate tree (Bazel, Buck) set it to a relative path.
+            let manifest_dir = {
+                let dir = PathBuf::from(manifest_dir);
+                dir.canonicalize().unwrap_or(dir)
+            } &&
             // If the `base` doesn't start with the same path as `CARGO_MANIFEST_DIR`, it likely
             // means that we're in a macro, so better use the absolute path in this case.
             !base.starts_with(manifest_dir)
@@ -158,4 +166,37 @@ fn test_diff_paths() {
             Some("templates/empty.txt".into()),
         );
     }
+}
+
+/// `CARGO_MANIFEST_DIR` may name the crate root through a symlink, or by a relative path, while
+/// `base` has been canonicalized. Comparing the two textually then fails even though they are the
+/// same directory, and `diff_paths()` falls back to an absolute path. That absolute path is
+/// emitted as `include_bytes!`, so it reaches rustc's `SourceMap` and feeds the crate hash --
+/// making the crate's SVH depend on where the project is checked out. Build systems that stage
+/// sources into a separate build tree (Bazel, Buck) hit this.
+#[test]
+#[cfg(unix)]
+fn test_diff_paths_manifest_dir_via_symlink() {
+    use std::fs;
+
+    let root = std::env::temp_dir().join(format!("askama-diff-paths-{}", std::process::id()));
+    let real = root.join("real_crate");
+    let link = root.join("linked_crate");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(real.join("templates")).unwrap();
+    fs::write(real.join("templates").join("empty.txt"), "").unwrap();
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+
+    // What `caller_dir()` produces: the canonicalized directory of the calling source file.
+    let base = real.canonicalize().unwrap();
+    let template = base.join("templates").join("empty.txt");
+
+    // `CARGO_MANIFEST_DIR` names the same directory, but by way of the symlink.
+    assert_eq!(
+        diff_paths(&template, &base, Some(link.to_str().unwrap().to_owned()),),
+        Some("templates/empty.txt".into()),
+        "a manifest dir reached through a symlink must still count as the same crate",
+    );
+
+    fs::remove_dir_all(&root).unwrap();
 }


### PR DESCRIPTION
### The problem

`caller_dir()` produces the directory that `rel_path()` diffs template paths against.
`Config::find_template()` always canonicalizes the template path, but `caller_dir()` does not
canonicalize its side, and `diff_paths()` compares `CARGO_MANIFEST_DIR` against it textually.
When those disagree, `diff_paths()` falls back to an absolute path.

That path is emitted as `include_bytes!(..)`, so it lands in rustc's `SourceMap`, which feeds
`crate_hash`. The result is that **the SVH of any crate using `#[derive(Template)]` depends on
where the project is checked out on disk.**

Build systems that stage sources as symlinks into a separate build tree (Bazel, Buck) hit this
squarely: the source file is a symlink into the real checkout while the directory holding it is
real, and `CARGO_MANIFEST_DIR` is set relative to the build tree.

Two builds of byte-identical sources then produce rlibs that differ *only* in their 16-byte SVH
field. A consumer compiled against one cannot be linked against the other. Under a shared build
cache — where the action key is computed over workspace-relative inputs and is therefore
identical across checkouts — the two rlibs get served interchangeably, and a build that mixes a
cache-served consumer with a locally rebuilt dependency fails with:

```
error[E0463]: can't find crate for `my_crate`
 --> my_crate/src/main.rs:3:5
  |
3 | use my_crate::commands::run;
  |     ^^^^^^^^^^^ can't find crate
```

Note that names the *consumer*, with no note pointing at the dependency whose SVH actually
moved — which makes this very hard to attribute. It took a while to track down on our side.

On 0.15.4 the emitted path looks like this, where the `../` count and the embedded directory
name both derive from the absolute checkout path:

```
src/generators/cpp/../../../../../../../../<checkout-dir>/templates/struct.askama.cpp
```

On current `main` the mismatch is absolute-vs-relative instead, so `diff_paths()` returns the
full absolute template path.

### The change

- `caller_dir()` resolves the calling source file before taking its parent directory, so both
  sides of the diff are rooted in the same tree. Resolving the *parent* instead would not work
  under Bazel — the symlink that has to be followed is the file, not its directory.
- `diff_paths()` resolves `CARGO_MANIFEST_DIR` before the `starts_with` check, so a manifest dir
  given relatively, or reaching the crate through a symlink, still counts as the same crate
  rather than forcing the absolute-path fallback.

Both use `canonicalize().unwrap_or(..)`, so behaviour is unchanged wherever a path cannot be
resolved — including the existing `test_diff_paths` cases, whose paths do not exist on disk.

Adds a regression test for a manifest dir reached through a symlink. It fails without the
`diff_paths()` change and passes with it.

### Verification

- Upstream test suite: 46 passed, 0 failed (`cargo test -p askama_derive`).
- The equivalent fix applied to 0.15.4 was verified end-to-end in a real Bazel build: the same
  commit built from two checkout paths of differing depth, each fully independent (no cache hits,
  ~3100 sandboxed actions), previously produced rlibs differing in exactly the 16 SVH bytes and
  now produces **byte-identical** rlibs. It is also now byte-identical between a locally
  sandboxed build and remote execution in a container, which previously disagreed.

### Why draft

The 0.15.4-shaped fix is what I have exercised in a full build; `main` has moved on enough that I
have not run our build against it. I would also value your read on the `CARGO_MANIFEST_DIR`
`starts_with` heuristic — resolving both sides seemed like the minimal change that preserves its
intent, but you know what that check is defending against better than I do. Happy to reshape it.
